### PR TITLE
DOC: Update homepage/contributors/iconurl metadata specified in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,11 @@ project(SlicerAutoscoperM)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/SlicerAutoscoperM")
+set(EXTENSION_HOMEPAGE "https://autoscoperm.slicer.org/")
 set(EXTENSION_CATEGORY "Tracking")
-set(EXTENSION_CONTRIBUTORS "Bardiya Akhbari (Brown University), Amy Morton (Brown University)")
+set(EXTENSION_CONTRIBUTORS "Anthony Lombardi (Kitware), Amy Morton (Brown University), Bardiya Akhbari (Brown University), Beatriz Paniagua (Kitware), Jean-Christophe Fillion-Robin (Kitware)")
 set(EXTENSION_DESCRIPTION "SlicerAutoscoperM is a 2D to 3D image registration multi-modal software developed as a tool to investigate intra-articular joint motion during dynamic tasks.")
-set(EXTENSION_ICONURL "./SlicerAutoscoperM.png")
+set(EXTENSION_ICONURL "https://raw.githubusercontent.com/BrownBiomechanics/SlicerAutoscoperM/main/SlicerAutoscoperM.png")
 set(EXTENSION_SCREENSHOTURLS "http://www.example.com/Slicer/Extensions/SlicerAutoscoperM/Screenshots/1.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 


### PR DESCRIPTION
* Fix iconurl to use the `raw.githubusercontent.com` url
* Update contributors to match list introcuced in https://github.com/BrownBiomechanics/SlicerAutoscoperM/commit/bbab4dface5dabf8e5639b3d1af0954719cd3e34 through:
  * https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/7