### PR TITLE
Support standalone build as extension

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -233,6 +233,13 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """
         Run processing when user clicks "Apply" button.
         """
+        import sys  # noqa: F401
+
+        if sys.platform == "darwin":
+            slicer.util.messageBox("AutoscoperM is not supported on this platform.<br>"
+                "See <a href='https://autoscoperm.slicer.org'>https://autoscoperm.slicer.org</a> for details.")
+            return
+
         import shutil  # noqa: F401
 
         executablePath = shutil.which("autoscoper")

--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -295,6 +295,7 @@ class AutoscoperMLogic(ScriptedLoadableModuleLogic):
             from PyAutoscoper.connect import AutoscoperConnection  # noqa: F401
         except ImportError:
             slicer.util.pip_install("PyAutoscoper~=1.1.0")
+            from PyAutoscoper.connect import AutoscoperConnection  # noqa: F401
 
         if self.AutoscoperSocket:
             logging.warning("connection to Autoscoper is already established")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,27 @@ set(EXTENSION_DESCRIPTION "SlicerAutoscoperM is a 2D to 3D image registration mu
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/BrownBiomechanics/SlicerAutoscoperM/main/SlicerAutoscoperM.png")
 set(EXTENSION_SCREENSHOTURLS "https://github.com/BrownBiomechanics/SlicerAutoscoperM/releases/download/docs-resources/AutoscoperMainWindow.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
+set(EXTENSION_BUILD_SUBDIRECTORY inner-build)
+
+set(SUPERBUILD_TOPLEVEL_PROJECT inner)
 
 #-----------------------------------------------------------------------------
 # Extension dependencies
 find_package(Slicer REQUIRED)
 include(${Slicer_USE_FILE})
+mark_as_superbuild(Slicer_DIR)
+
+find_package(Git REQUIRED)
+mark_as_superbuild(GIT_EXECUTABLE)
+
+#-----------------------------------------------------------------------------
+# SuperBuild setup
+option(${EXTENSION_NAME}_SUPERBUILD "Build ${EXTENSION_NAME} and the projects it depends on." ON)
+mark_as_advanced(${EXTENSION_NAME}_SUPERBUILD)
+if(${EXTENSION_NAME}_SUPERBUILD)
+  include("${CMAKE_CURRENT_SOURCE_DIR}/SuperBuild.cmake")
+  return()
+endif()
 
 #-----------------------------------------------------------------------------
 # Extension modules
@@ -23,5 +39,12 @@ add_subdirectory(AutoscoperM)
 ## NEXT_MODULE
 
 #-----------------------------------------------------------------------------
+set(EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS)
+list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Autoscoper_DIR};Autoscoper;ALL;/")
+set(${EXTENSION_NAME}_CPACK_INSTALL_CMAKE_PROJECTS "${EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS}" CACHE STRING "List of external projects to install" FORCE)
+
+#-----------------------------------------------------------------------------
+list(APPEND CPACK_INSTALL_CMAKE_PROJECTS "${CMAKE_BINARY_DIR};${EXTENSION_NAME};ALL;/")
+list(APPEND CPACK_INSTALL_CMAKE_PROJECTS "${${EXTENSION_NAME}_CPACK_INSTALL_CMAKE_PROJECTS}")
 include(${Slicer_EXTENSION_GENERATE_CONFIG})
 include(${Slicer_EXTENSION_CPACK})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ set(EXTENSION_CATEGORY "Tracking")
 set(EXTENSION_CONTRIBUTORS "Anthony Lombardi (Kitware), Amy Morton (Brown University), Bardiya Akhbari (Brown University), Beatriz Paniagua (Kitware), Jean-Christophe Fillion-Robin (Kitware)")
 set(EXTENSION_DESCRIPTION "SlicerAutoscoperM is a 2D to 3D image registration multi-modal software developed as a tool to investigate intra-articular joint motion during dynamic tasks.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/BrownBiomechanics/SlicerAutoscoperM/main/SlicerAutoscoperM.png")
-set(EXTENSION_SCREENSHOTURLS "http://www.example.com/Slicer/Extensions/SlicerAutoscoperM/Screenshots/1.png")
+set(EXTENSION_SCREENSHOTURLS "https://github.com/BrownBiomechanics/SlicerAutoscoperM/releases/download/docs-resources/AutoscoperMainWindow.png")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies
 
 #-----------------------------------------------------------------------------

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -1,0 +1,55 @@
+#-----------------------------------------------------------------------------
+# External project common settings
+#-----------------------------------------------------------------------------
+
+set(ep_common_c_flags "${CMAKE_C_FLAGS_INIT} ${ADDITIONAL_C_FLAGS}")
+set(ep_common_cxx_flags "${CMAKE_CXX_FLAGS_INIT} ${ADDITIONAL_CXX_FLAGS}")
+
+#-----------------------------------------------------------------------------
+# Top-level "external" project
+#-----------------------------------------------------------------------------
+
+# Extension dependencies
+foreach(dep ${EXTENSION_DEPENDS})
+  mark_as_superbuild(${dep}_DIR)
+endforeach()
+
+set(proj ${SUPERBUILD_TOPLEVEL_PROJECT})
+
+# Project dependencies
+set(${proj}_DEPENDS
+   Autoscoper
+   )
+
+ExternalProject_Include_Dependencies(${proj}
+  PROJECT_VAR proj
+  SUPERBUILD_VAR ${EXTENSION_NAME}_SUPERBUILD
+  )
+
+ExternalProject_Add(${proj}
+  ${${proj}_EP_ARGS}
+  DOWNLOAD_COMMAND ""
+  INSTALL_COMMAND ""
+  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}
+  BINARY_DIR ${EXTENSION_BUILD_SUBDIRECTORY}
+  CMAKE_CACHE_ARGS
+    # Compiler settings
+    -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+    -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+    -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+    -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+    -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+    -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
+    -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
+    # Output directories
+    -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
+    -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH=${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+    # Superbuild
+    -D${EXTENSION_NAME}_SUPERBUILD:BOOL=OFF
+    -DEXTENSION_SUPERBUILD_BINARY_DIR:PATH=${${EXTENSION_NAME}_BINARY_DIR}
+  DEPENDS
+    ${${proj}_DEPENDS}
+  )
+
+ExternalProject_AlwaysConfigure(${proj})

--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -1,0 +1,85 @@
+
+set(proj Autoscoper)
+
+# Set dependency list
+set(${proj}_DEPENDS
+  ""
+  )
+
+# Include dependent projects if any
+ExternalProject_Include_Dependencies(${proj} PROJECT_VAR proj)
+
+if(${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj})
+  message(FATAL_ERROR "Enabling ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj} is not supported !")
+endif()
+
+# Sanity checks
+if(DEFINED Autoscoper_DIR AND NOT EXISTS ${Autoscoper_DIR})
+  message(FATAL_ERROR "Autoscoper_DIR [${Autoscoper_DIR}] variable is defined but corresponds to nonexistent directory")
+endif()
+
+if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${proj})
+
+  set(EP_SOURCE_DIR ${CMAKE_BINARY_DIR}/${proj})
+  set(EP_BINARY_DIR ${CMAKE_BINARY_DIR}/${proj}-build)
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_REPOSITORY
+    "https://github.com/BrownBiomechanics/Autoscoper.git"
+    QUIET
+  )
+
+  ExternalProject_SetIfNotDefined(
+    Slicer_${proj}_GIT_TAG
+    "e0453146ab1ee401552192352d66b39c61caed79"
+    QUIET
+  )
+
+  # Workaround improper generation of target file when destination associated
+  # with "install(EXPORT <export-name> DESTINATION <dir>)" start with "./"
+  if(NOT APPLE)
+    set(Slicer_INSTALL_THIRDPARTY_LIB_DIR ${Slicer_THIRDPARTY_LIB_DIR})
+  endif()
+
+  ExternalProject_Add(${proj}
+    ${${proj}_EP_ARGS}
+    GIT_REPOSITORY "${Slicer_${proj}_GIT_REPOSITORY}"
+    GIT_TAG "${Slicer_${proj}_GIT_TAG}"
+    SOURCE_DIR ${EP_SOURCE_DIR}
+    BINARY_DIR ${EP_BINARY_DIR}
+    CMAKE_CACHE_ARGS
+      # Compiler settings
+      -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}
+      -DCMAKE_C_FLAGS:STRING=${ep_common_c_flags}
+      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
+      -DCMAKE_CXX_FLAGS:STRING=${ep_common_cxx_flags}
+      -DCMAKE_CXX_STANDARD:STRING=${CMAKE_CXX_STANDARD}
+      -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=${CMAKE_CXX_STANDARD_REQUIRED}
+      -DCMAKE_CXX_EXTENSIONS:BOOL=${CMAKE_CXX_EXTENSIONS}
+      # Output directories
+      -DCMAKE_RUNTIME_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_BIN_DIR}
+      -DCMAKE_LIBRARY_OUTPUT_DIRECTORY:PATH=${CMAKE_BINARY_DIR}/${Slicer_THIRDPARTY_LIB_DIR}
+      -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY:PATH=${CMAKE_ARCHIVE_OUTPUT_DIRECTORY}
+      # Install directories
+      -DAutoscoper_BIN_DIR:STRING=${Slicer_INSTALL_THIRDPARTY_BIN_DIR}
+      -DAutoscoper_LIB_DIR:STRING=${Slicer_INSTALL_THIRDPARTY_LIB_DIR}
+      # Options
+      -DAutoscoper_SUPERBUILD:BOOL=ON
+      -DAutoscoper_INSTALL_Qt_LIBRARIES:BOOL=OFF
+      -DAutoscoper_INSTALL_SAMPLE_DATA:BOOL=OFF
+      -DAutoscoper_RENDERING_BACKEND:STRING=OpenCL
+      -DQt5_DIR:PATH=${Qt5_DIR}
+      # Dependencies
+      # NA
+      INSTALL_COMMAND ""
+    DEPENDS
+      ${${proj}_DEPENDS}
+    )
+
+  set(${proj}_DIR ${EP_BINARY_DIR}/Autoscoper-build)
+
+else()
+  ExternalProject_Add_Empty(${proj} DEPENDS ${${proj}_DEPENDS})
+endif()
+
+mark_as_superbuild(${proj}_DIR:PATH)


### PR DESCRIPTION
## Add Autoscoper external project
    
This pull-request updates the build-system based on the "SuperBuild" extension template and adds the "Autoscoper" external project referencing BrownBiomechanics/Autoscoper@e045314

### Install & packaging

* It configures Autoscoper setting output & install directories based of `Slicer_INSTALL_THIRDPARTY_*_DIR` variables.

* It configures Autoscoper with the following options:
  - `Autoscoper_INSTALL_Qt_LIBRARIES` set to `OFF`
  - `Autoscoper_INSTALL_SAMPLE_DATA` set to `OFF`

* In top-level CMakeLists.txt, it updates `EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS` appending the Autoscoper project. This ensures Autoscoper and its dependencies are installed.

### Notes

* Attempting to launch autoscoper from the build tree is not yet supported.

* Attempting to launch autoscoper on macOS is not supported. A pop indicating so is displayed.

### Associated pull-requests

SlicerAutoscoperM:
* https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/7
* https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/9

autoscoperm.slicer.org:
* https://github.com/BrownBiomechanics/autoscoperm.slicer.org/pull/5

Autoscoper:

* https://github.com/BrownBiomechanics/Autoscoper/pull/95
* https://github.com/BrownBiomechanics/Autoscoper/pull/97
* https://github.com/BrownBiomechanics/Autoscoper/pull/99
* https://github.com/BrownBiomechanics/Autoscoper/pull/100
* https://github.com/BrownBiomechanics/Autoscoper/pull/102
* https://github.com/BrownBiomechanics/Autoscoper/pull/103
* https://github.com/BrownBiomechanics/Autoscoper/pull/104
* https://github.com/BrownBiomechanics/Autoscoper/pull/105
* https://github.com/BrownBiomechanics/Autoscoper/pull/106
* https://github.com/BrownBiomechanics/Autoscoper/pull/107
* https://github.com/BrownBiomechanics/Autoscoper/pull/108
* https://github.com/BrownBiomechanics/Autoscoper/pull/109
