### PR TITLE
COMP: Update Autoscoper to fix build using gcc7 & specify OpenGL_GL_PREFERENCE

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -31,14 +31,28 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "e0453146ab1ee401552192352d66b39c61caed79"
+    "60b3d6ec0a5e4b796ef97baaa7a3a9b0351280e7"
     QUIET
   )
+
+  set(EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS)
 
   # Workaround improper generation of target file when destination associated
   # with "install(EXPORT <export-name> DESTINATION <dir>)" start with "./"
   if(NOT APPLE)
     set(Slicer_INSTALL_THIRDPARTY_LIB_DIR ${Slicer_THIRDPARTY_LIB_DIR})
+  endif()
+
+  if(UNIX AND NOT APPLE)
+    if(NOT DEFINED OpenGL_GL_PREFERENCE)
+      set(OpenGL_GL_PREFERENCE "LEGACY")
+    endif()
+    if(NOT "${OpenGL_GL_PREFERENCE}" MATCHES "^(LEGACY|GLVND)$")
+      message(FATAL_ERROR "OpenGL_GL_PREFERENCE variable is expected to be set to LEGACY or GLVND")
+    endif()
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DOpenGL_GL_PREFERENCE:STRING=${OpenGL_GL_PREFERENCE}
+      )
   endif()
 
   ExternalProject_Add(${proj}
@@ -71,7 +85,8 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       -DQt5_DIR:PATH=${Qt5_DIR}
       # Dependencies
       # NA
-      INSTALL_COMMAND ""
+      ${EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS}
+    INSTALL_COMMAND ""
     DEPENDS
       ${${proj}_DEPENDS}
     )


### PR DESCRIPTION
### Fix build using gcc7

This fixes the following build error reported when building with GCC v7. This corresponds to the compiler associated with the [SlicerBuildEnvironment](https://github.com/Slicer/SlicerBuildEnvironment) `slicer/buildenv-qt5-centos7:latest` used to build & package Slicer application and associated extensions on Linux.

```
[ 50%] Building CXX object autoscoper/CMakeFiles/autoscoper.dir/src/net/Socket.cpp.o
/path/to/SlicerAutoscoperM-build/Autoscoper/autoscoper/src/net/Socket.cpp:49:10: fatal error: filesystem: No such file or directory
 #include <filesystem>
          ^~~~~~~~~~~~
```

GCC v7 does not implement `<filesystem>` but it does have the Filesystem Technical Specification which is in `<experimental/filesystem>`.

References:
* https://en.cppreference.com/w/cpp/header/experimental/filesystem
* https://en.cppreference.com/w/cpp/header/filesystem


### OpenGL_GL_PREFERENCE

This addresses the following warning setting `OpenGL_GL_PREFERENCE` to `LEGACY` and ensuring autoscoper can be used on system without the `GLVND` (GL Vendor-Neutral Dispatch) library.

```
CMake Warning (dev) at /usr/share/cmake-3.22/Modules/FindOpenGL.cmake:315 (message):
  Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
  available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  FindOpenGL found both a legacy GL library:

    OPENGL_gl_LIBRARY: /usr/lib64/libGL.so

  and GLVND libraries for OpenGL and GLX:

    OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so
    OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so

  OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
  compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
  autoscoper/CMakeLists.txt:1 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```


### List of Autoscoper changes

$ git shortlog e0453146a..60b3d6ec0 --no-merges
Jean-Christophe Fillion-Robin (3):
      COMP: Fix build on system only having <experimental/filesystem>
      COMP: Add FindFilesystem CMake module to detect required filesystem libraries
      COMP: Initialize OpenGL_GL_PREFERENCE and pass if down to inner-build