### PR TITLE
COMP: Build and package Autoscoper only on supported platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,9 @@ add_subdirectory(AutoscoperM)
 
 #-----------------------------------------------------------------------------
 set(EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS)
-list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Autoscoper_DIR};Autoscoper;ALL;/")
+if(DEFINED Autoscoper_DIR)
+  list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Autoscoper_DIR};Autoscoper;ALL;/")
+endif()
 set(${EXTENSION_NAME}_CPACK_INSTALL_CMAKE_PROJECTS "${EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS}" CACHE STRING "List of external projects to install" FORCE)
 
 #-----------------------------------------------------------------------------

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -18,8 +18,18 @@ set(proj ${SUPERBUILD_TOPLEVEL_PROJECT})
 
 # Project dependencies
 set(${proj}_DEPENDS
-   Autoscoper
    )
+
+set(_autoscoper_supported TRUE)
+if(APPLE)
+  set(_autoscoper_supported FALSE)
+endif()
+
+if(_autoscoper_supported)
+  list(APPEND ${proj}_DEPENDS
+    Autoscoper
+    )
+endif()
 
 ExternalProject_Include_Dependencies(${proj}
   PROJECT_VAR proj


### PR DESCRIPTION
This commit excludes Autoscoper dependency if build on macOS.