### PR TITLE
Add GitHub actions workflows

### DIFF
--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -1,0 +1,36 @@
+name: 'Commit Message Check'
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Prefix
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^(ENH|PERF|BUG|STYLE|DOC|COMP): ([A-Z])+'
+          flags: 'gm'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          error: 'The first line has to start with a commit prefix, followed by a colon and space, and then followed by a message with a capital letter (e.g "ENH: Add support for awesome feature"). For more details on other requirements, see https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits'
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true
+      - name: Check Line Length
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^[^#].{1,78}$'
+          error: 'The maximum line length of 78 characters is exceeded. For more details, see https://slicer.readthedocs.io/en/latest/developer_guide/style_guide.html#commits'
+          excludeDescription: 'true' # optional: this excludes the description body of a pull request
+          excludeTitle: 'true' # optional: this excludes the title of a pull request
+          checkAllCommitMessages: 'true' # optional: this checks all commits associated with a pull request
+          accessToken: ${{ secrets.GITHUB_TOKEN }} # github access token is only required if checkAllCommitMessages is true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,21 @@
+name: pre-commit
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,3 @@ repos:
     rev: 22.3.0
     hooks:
     - id: black
-      args: [--line-length=120]

--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -236,8 +236,10 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         import sys  # noqa: F401
 
         if sys.platform == "darwin":
-            slicer.util.messageBox("AutoscoperM is not supported on this platform.<br>"
-                "See <a href='https://autoscoperm.slicer.org'>https://autoscoperm.slicer.org</a> for details.")
+            slicer.util.messageBox(
+                "AutoscoperM is not supported on this platform.<br>"
+                "See <a href='https://autoscoperm.slicer.org'>https://autoscoperm.slicer.org</a> for details."
+            )
             return
 
         import shutil  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 120


### PR DESCRIPTION
Supersedes:
* https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/20

To ensure the GitHub actions workflow is triggered for the first time, this new pull-request was re-created from a branch directly pushed to the repository.