### PR TITLE
BUG: Fix Autoscoper launcher on system without system OpenCL library

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -98,6 +98,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   # library paths
   set(${proj}_LIBRARY_PATHS_LAUNCHER_BUILD
+    ${EP_BINARY_DIR}/OpenCL-ICD-Loader-build/${Slicer_THIRDPARTY_BIN_DIR}/${CMAKE_CFG_INTDIR} # OpenCL library
     ${EP_BINARY_DIR}/GLEW-Install/${Slicer_THIRDPARTY_BIN_DIR} # Glew library
     ${EP_BINARY_DIR}/TIFF-Install/${Slicer_THIRDPARTY_BIN_DIR} # TIFF library
     )


### PR DESCRIPTION
This commit is a follow-up of 690c9d570 (COMP: Update build tree launcher settings to fix execution of Autoscoper) ensuring that Autoscoper can be started on system without OpenCL.dll already in the path.