### PR TITLE
ENH: Update Autoscoper

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -31,7 +31,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "60b3d6ec0a5e4b796ef97baaa7a3a9b0351280e7"
+    "b29d30f51f84a77dc70c0e1ee6b99ecf5a3f64d8"
     QUIET
   )
 


### PR DESCRIPTION
### Highlighted Autoscoper changes

* Fix trailing comma when saving single volume tracking data so that the file can be loaded by other CVS reader (e.g numpy)
  - Before: `X_data, Y_data, Z_data, YAW_data, PITCH_data, ROLL_data,`
  - After: `X_data, Y_data, Z_data, YAW_data, PITCH_data, ROLL_data`
  - See BrownBiomechanics/Autoscoper#130

* Documentation updates

* Update sources to explicitly reference `std` namespace.

* Add support for 3D kernels (`Kernel::block3d` and `Kernel::grid3d`)
  - Not yet used
  - It was originally integrated to support the computation of "Distance field" in  BrownBiomechanics/Autoscoper#87 which was closed in favor of BrownBiomechanics/Autoscoper#128

### List of Autoscoper changes

```
$ git shortlog 60b3d6ec0..b29d30f51 --no-merges
Anthony Lombardi (20):
      ENH: Update OpenCL wrapper to support 3D kernels (PR-113)
      DOC: Fix typos in PyAutoscoper docstrings
      DOC: Set up Markdown Sphinx docs
      DOC: Add Documentation for PyAutoscoper
      DOC: Add About Autoscoper section to RTD
      DOC: Add getting started and user interface to RTD
      DOC: Add MATLAB socket control docs to RTD
      DOC: Add dev guide to RTD
      DOC: Update the license info on the home page
      DOC: Add UI description
      DOC: Add instructions for remote GPU access
      DOC: Add tutorials for sample and custom data
      DOC: Add file specifications
      ENH: Add .readthedocs.yaml to install required packages
      ENH: Make content take up 100% of the screen width
      DOC: Add tutorial for filters
      DOC: Update History and Getting Started
      DOC: Update README for PyAutoscoper to point to RTD
      DOC: Add tutorial descriptions and reference on getting started
      BUG: Fix trailing comma when saving single volume tracking data

Jean-Christophe Fillion-Robin (24):
      STYLE: Update "line-length" black settings from 88 to 120
      DOC: Add top-level license based on source file headers
      DOC: Update README adding a "License" section along with historical notes
      STYLE: Update black version specified in pre-commit config
      COMP: Update pre-commit config to ensure black always uses expected settings
      COMP: Explicitly reference "std" namespace
      DOC: Consistently add an empty line between header and content
      DOC: Strip trailing white spaces
      DOC: Add dedicated "About" top-level section
      DOC: Move SampleData description in "Getting Started"
      DOC: Move "Advanced Topics" after "User Interface" and "Tutorials"
      DOC: Fix headers in CONTRIBUTING document
      DOC: Fix cross-references warnings
      DOC: Update configuration removing invalid options
      DOC: Fix formatting of "Example" in "Camera Calibration File Format"
      DOC: Update "Getting Started" to fix reference to sample data
      ENH: Update NewTrialDialog UI file to use "OK" instead of "Ok"
      DOC: Fix miscellaneous typos
      DOC: Update PyAutoscoper document to use back-ticks around method names
      DOC: Tweak formatting of "Loading and Tracking Data" tutorial
      DOC: Use "AutoscoperM" instead of SAM in "Loading Custom Data" tutorial
      DOC: Ensure "Tutorials" are complete by relying on implicit link text
      STYLE: Remove obsolete comments from autoscoper/CMakeLists.txt
      COMP: Set autoscoper_set_env.sh permission flags only if configuring script
```