### PR TITLE
BUG: Fix observer warning

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -246,7 +246,9 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         # Unobserve previously selected parameter node and add an observer to the newly selected.
         # Changes of parameter node are observed so that whenever parameters are changed by a script or any other module
         # those are reflected immediately in the GUI.
-        if self._parameterNode is not None:
+        if self._parameterNode is not None and self.hasObserver(
+            self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode
+        ):
             self.removeObserver(self._parameterNode, vtk.vtkCommand.ModifiedEvent, self.updateGUIFromParameterNode)
         self._parameterNode = inputParameterNode
         if self._parameterNode is not None:


### PR DESCRIPTION
* Bug was initially fixed in the scripted module template in [PR #6720](https://github.com/Slicer/Slicer/pull/6720) from Slicer core.
* This module (AutoscoperM) was created in 2021 while the above PR was integrated in late 2022
* Closes #34 
* See also https://discourse.slicer.org/t/warning-of-observer-from-scripted-module-in-slicer-5-0-3/24735