### PR TITLE
COMP: Update Autoscoper to ensure OpenGL_GL_PREFERENCE is passed to GLEW project

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -31,7 +31,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "b1e1dcbcada159798a0002130441e2e1b5432d31"
+    "51f1d0cf3976baac34dff32a137e3fc4a1d043f1"
     QUIET
   )
 


### PR DESCRIPTION
This is a follow-up of these commits:
* ff793c571 (COMP: Update Autoscoper to fix build using gcc7 & specify OpenGL_GL_PREFERENCE)
* 3a4eef8ae (COMP: Fix initial configuration on Linux)


to fix the following warning:

```
  [  7%] Performing configure step for 'GLEW' loading initial cache file /work/Preview/S-0-E-b/SlicerAutoscoperM-build/Autoscoper-build/GLEW-prefix/tmp/GLEW-cache-Release.cmake CMake Warning (dev) at /usr/share/cmake-3.22/Modules/FindOpenGL.cmake:315 (message): Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when available.  Run "cmake --help-policy CMP0072" for policy details.  Use the cmake_policy command to set the policy and suppress this warning.

    FindOpenGL found both a legacy GL library:

      OPENGL_gl_LIBRARY: /usr/lib64/libGL.so

    and GLVND libraries for OpenGL and GLX:

      OPENGL_opengl_LIBRARY: /usr/lib64/libOpenGL.so
      OPENGL_glx_LIBRARY: /usr/lib64/libGLX.so

    OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
    compatibility with CMake 3.10 and below the legacy GL library will be used.
  Call Stack (most recent call first): CMakeLists.txt:43 (find_package) This warning is for project developers.  Use -Wno-dev to suppress it.
```

List of Autoscoper changes:

```
$ git shortlog b1e1dcbca..51f1d0cf3 --no-merges
Jean-Christophe Fillion-Robin (11):
      STYLE: Fix typos identified using codespell
      ENH: Update pre-commit configuration adding codespell
      ENH: Update PyAutoscoper required python from 3.6 to 3.8
      STYLE: Reduce length of Python docstrings and comments
      STYLE: Do not use multiple imports on one line in pyautoscoper-examples.py
      STYLE: Update PyAutoscoper to facilitate exception chaining
      STYLE: Update PyAutoscoper removing used of deprecated exception
      STYLE: Sort Python imports alphabetically
      ENH: Add support for running ruff
      DOC: Update "Get Help" section
      COMP: Pass OpenGL_GL_PREFERENCE to GLEW project
```