### PR TITLE
BUG: Fix VTK memory leak in partial volume gen

### DIFF
--- a/AutoscoperM/AutoscoperMLib/IO.py
+++ b/AutoscoperM/AutoscoperMLib/IO.py
@@ -262,7 +262,6 @@ def _createNewVolumeNode(nodeName: str) -> slicer.vtkMRMLVolumeNode:
     volumeNode.SetIJKToRASDirections(imageDirections)
     volumeNode.SetAndObserveImageData(imageData)
     volumeNode.CreateDefaultDisplayNodes()
-    volumeNode.CreateDefaultStorageNode()
     return volumeNode
 
 


### PR DESCRIPTION
* Regression was caused by the improper removal of the default storage node of the temp volume created during IO._castVolume
* Regression was initially introduced in 52b5bdc
* See https://github.com/Slicer/Slicer/issues/6099

![image](https://github.com/BrownBiomechanics/SlicerAutoscoperM/assets/30351234/0b8e8338-a6a4-4b29-88de-bbda544fc6dd)
