### PR TITLE
ENH: Update version of Autoscoper to include fixes for OpenCL and linux

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -31,7 +31,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "51f1d0cf3976baac34dff32a137e3fc4a1d043f1"
+    "75eb9ad5ac1ab490b1bb1f8e0f97bd60d86f8a99"
     QUIET
   )
 


### PR DESCRIPTION
* Updates Autoscoper to the latest version (as of `2023-09-18`)
* Includes fix for incorrect viewport calculations (causes OpenCL buffer error)
    * See https://github.com/BrownBiomechanics/Autoscoper/pull/204
* Includes fix for Linux build failures
    * See https://github.com/BrownBiomechanics/Autoscoper/pull/198