### PR TITLE
PERF: Update Autoscoper to include PSO optimization

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -31,7 +31,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "73eb359dcd70878c4b4c28471fd2684c08bd3014"
+    "4bdedd802034a1c341099d735010690105a106ad"
     QUIET
   )
 


### PR DESCRIPTION
Refactor the Particle Swarm Optimization (PSO) implementation by introducing a specialized Particle data structure alongside a particle collection. This structure allows us to efficiently manage and track computed Normalized Cross-Correlation (NCC) values for each particle. As a result, we now evaluate each particle only once per iteration, as opposed to between 2 and 5 times in the worst-case scenario.

This optimization has led to a remarkable reduction in per-frame execution time on a typical workstation using the OpenCL back-end, dropping it from the range of 9 to 18 seconds to a much-improved 3 to 6 seconds.

List of changes:

```
$ git shortlog 73eb359dc..4bdedd802 --no-merges
Anthony Lombardi (1):
      PERF: Introduce particle data structure for PSO
```