### PR TITLE
BUG: Update Autoscoper to include DRR projection fixes

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -31,7 +31,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4bdedd802034a1c341099d735010690105a106ad"
+    "4704f9b79f77b03dc5d59deca2c69b98c25164a6"
     QUIET
   )
 


### PR DESCRIPTION
List of changes:

```
$ git shortlog 4bdedd802..4704f9b79 --no-merges
Anthony Lombardi (2):
      BUG: Fix PSO Particle struct position initialization (#232)
      BUG: Clip bounds of DRR projection to the bounds of the radiograph

Jean-Christophe Fillion-Robin (1):
      DOC: Document Camera::calculateImagePlane
```