### PR TITLE
Support integrating backend-specific Autoscoper executable & enable CUDA backend

### DIFF
--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -25,17 +25,30 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_2">
        <item>
-        <widget class="QPushButton" name="startAutoscoper">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="toolTip">
-          <string>Start the Autoscoper executable bundled in the extension.</string>
-         </property>
-         <property name="text">
-          <string>Launch Autoscoper</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="launcherAutoscoperHorizontalLayout">
+         <item>
+          <widget class="QPushButton" name="startAutoscoper">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="toolTip">
+            <string>Start the Autoscoper executable bundled in the extension.</string>
+           </property>
+           <property name="text">
+            <string>Launch Autoscoper</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="autoscoperRenderingBackendComboBox"/>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="QPushButton" name="closeAutoscoper">

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,18 +27,7 @@ mark_as_superbuild(GIT_EXECUTABLE)
 #-----------------------------------------------------------------------------
 # Options
 
-set(_reason "")
-if(DEFINED ENV{Autoscoper_RENDERING_BACKEND})
-  set(_reason " (initialized from env. variable)")
-  set(_default_backend $ENV{Autoscoper_RENDERING_BACKEND})
-elseif(NOT DEFINED Autoscoper_RENDERING_BACKEND)
-  set(_reason " (initialized from default value)")
-  set(_default_backend "OpenCL")
-endif()
-
-set(Autoscoper_RENDERING_BACKEND "${_default_backend}" CACHE STRING "Backend to use for DRR and radiograph rendering")
-set_property(CACHE Autoscoper_RENDERING_BACKEND PROPERTY STRINGS "CUDA" "OpenCL")
-message(STATUS "Setting Autoscoper_RENDERING_BACKEND to ${Autoscoper_RENDERING_BACKEND}${_reason}")
+# NA
 
 #-----------------------------------------------------------------------------
 # SuperBuild setup
@@ -59,17 +48,22 @@ add_subdirectory(VirtualRadiographGeneration)
 
 #-----------------------------------------------------------------------------
 set(EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS)
-if(DEFINED Autoscoper_DIR)
-  list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${Autoscoper_DIR};Autoscoper;ALL;/")
-endif()
+foreach(varname IN LISTS ${SUPERBUILD_TOPLEVEL_PROJECT}_EP_LABEL_Autoscoper_DIRS)
+  if(DEFINED ${varname})
+    message(STATUS "Adding install rules for Autoscoper in ${varname}")
+    list(APPEND EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS "${${varname}};Autoscoper;ALL;/")
+  endif()
+endforeach()
 set(${EXTENSION_NAME}_CPACK_INSTALL_CMAKE_PROJECTS "${EXTENSION_CPACK_INSTALL_CMAKE_PROJECTS}" CACHE STRING "List of external projects to install" FORCE)
 
-if(APPLE)
+if(APPLE OR TRUE)
   set(EXTENSION_FIXUP_BUNDLE_LIBRARY_DIRECTORIES)
-  set(GLEW_RUNTIME_LIBRARY_DIR "${Autoscoper_DIR}/../Autoscoper-build/GLEW-install/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}")
-  list(APPEND EXTENSION_FIXUP_BUNDLE_LIBRARY_DIRECTORIES ${GLEW_RUNTIME_LIBRARY_DIR})
-  set(TIFF_RUNTIME_LIBRARY_DIR "${Autoscoper_DIR}/../Autoscoper-build/TIFF-install/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}")
-  list(APPEND EXTENSION_FIXUP_BUNDLE_LIBRARY_DIRECTORIES ${TIFF_RUNTIME_LIBRARY_DIR})
+  foreach(varname IN LISTS ${SUPERBUILD_TOPLEVEL_PROJECT}_EP_LABEL_Autoscoper_DIRS)
+    set(GLEW_RUNTIME_LIBRARY_DIR "${${varname}}/../GLEW-install/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}")
+    list(APPEND EXTENSION_FIXUP_BUNDLE_LIBRARY_DIRECTORIES ${GLEW_RUNTIME_LIBRARY_DIR})
+    set(TIFF_RUNTIME_LIBRARY_DIR "${${varname}}/../TIFF-install/${Slicer_INSTALL_THIRDPARTY_LIB_DIR}")
+    list(APPEND EXTENSION_FIXUP_BUNDLE_LIBRARY_DIRECTORIES ${TIFF_RUNTIME_LIBRARY_DIR})
+  endforeach()
   set(${EXTENSION_NAME}_FIXUP_BUNDLE_LIBRARY_DIRECTORIES "${EXTENSION_FIXUP_BUNDLE_LIBRARY_DIRECTORIES}" CACHE STRING "List of directories to look up libraries to copy into the application package" FORCE)
 endif()
 

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -18,7 +18,7 @@ set(proj ${SUPERBUILD_TOPLEVEL_PROJECT})
 
 # Project dependencies
 set(${proj}_DEPENDS
-  Autoscoper
+  Autoscoper-OpenCL
   )
 
 ExternalProject_Include_Dependencies(${proj}

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -21,6 +21,19 @@ set(${proj}_DEPENDS
   Autoscoper-OpenCL
   )
 
+if(DEFINED ENV{SlicerAutoscoperM_CUDA_PATH})
+  set(ENV{CUDA_PATH} $ENV{SlicerAutoscoperM_CUDA_PATH})
+endif()
+
+find_package(CUDA)
+if(CUDA_FOUND)
+  # Variable expected by find_package(CUDA) also used in Autoscoper
+  mark_as_superbuild(VARS CUDA_TOOLKIT_ROOT_DIR PROJECTS Autoscoper-CUDA)
+  list(APPEND ${proj}_DEPENDS
+    Autoscoper-CUDA
+    )
+endif()
+
 ExternalProject_Include_Dependencies(${proj}
   PROJECT_VAR proj
   SUPERBUILD_VAR ${EXTENSION_NAME}_SUPERBUILD

--- a/SuperBuild/External_Autoscoper-CUDA.cmake
+++ b/SuperBuild/External_Autoscoper-CUDA.cmake
@@ -1,0 +1,3 @@
+set(proj Autoscoper-CUDA)
+set(${proj}_RENDERING_BACKEND CUDA)
+include(${CMAKE_CURRENT_LIST_DIR}/External_Autoscoper.cmake)

--- a/SuperBuild/External_Autoscoper-OpenCL.cmake
+++ b/SuperBuild/External_Autoscoper-OpenCL.cmake
@@ -1,0 +1,3 @@
+set(proj Autoscoper-OpenCL)
+set(${proj}_RENDERING_BACKEND OpenCL)
+include(${CMAKE_CURRENT_LIST_DIR}/External_Autoscoper.cmake)

--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -35,7 +35,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "d476e2cbb4fc72a4dea5f4d467676bf9b978d8ce"
+    "644473784dd0018f5bf8518c5e5322092e4da07d"
     QUIET
   )
 


### PR DESCRIPTION
Build-system updates:

- Removed support for setting Autoscoper_RENDERING_BACKEND option.
- Introduced an explicit AutoscoperM-OpenCL external project.
- Associated Autoscoper "_DIR" variables with the label "Autoscoper_DIRS" allowing to update install and fix-up rules based on the different Autoscoper builds.
- Updated external project variables depending on the project name to use `${proj}_` prefix instead of the hard-coded `Autoscoper_` one.


AutoscoperM module updates:
- Updated AutoscoperM module to include a combobox for selecting the rendering backend. The combobox is dynamically populated based on the available Autoscoper executables found in the environment (e.g., autoscoper-CUDA or autoscoper-OpenCL).

Note: The distribution of the CUDA variant of Autoscoper ("autoscoper-CUDA") will be integrated in subsequent commits.

List of Autoscoper updates:

```
$ git shortlog d476e2cbb..644473784 --no-merges
Jean-Christophe Fillion-Robin (2):
      COMP: Update cutil headers to fix build against SDK without cufft library
      COMP: Ensure Autoscoper inner-build is built with expected CUDA toolkit
```