### PR TITLE
ENH: Update Autoscoper

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -35,7 +35,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "644473784dd0018f5bf8518c5e5322092e4da07d"
+    "48fcab9734ba44ca101826156a0d57de99891f12"
     QUIET
   )
 


### PR DESCRIPTION
Highlights:
* Add support 16 and 32-bit radiograph
* Add support for toggling DRR visibility using python or MatLab client

List of changes:

```
$ git shortlog 644473784..48fcab973 --no-merges
Anthony Lombardi (4):
      ENH: Add support for 16 and 32-bit radiograph images
      BUG: Ensure CUDA RayCaster is sets visible to true by default
      ENH: Socket control drr visibility toggle
      ENH: Generalize background image calculations to support 16/32-bit radiographs (#245)
```

Related Autoscoper pull requests:
* https://github.com/BrownBiomechanics/Autoscoper/pull/76
* https://github.com/BrownBiomechanics/Autoscoper/pull/245
* https://github.com/BrownBiomechanics/Autoscoper/pull/248
* https://github.com/BrownBiomechanics/Autoscoper/pull/251