### PR TITLE
ENH: Update Autoscoper modernizing CUDA integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.13.4)
+cmake_minimum_required(VERSION 3.20.6)
 
 project(SlicerAutoscoperM)
 

--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -35,7 +35,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "7df4365ecb1919fa10cb3e67a836467db0686f2e"
+    "22b1a41e0b7b6a2de330f436d8834d1a0b96a3ac"
     QUIET
   )
 


### PR DESCRIPTION
This commit updates the Autoscoper project by replacing the deprecated[^1] `FindCUDA` CMake module with the more robust and first-class support for CUDA language. The changes leverage the following key features introduced in various CMake versions:

[^1]: https://cmake.org/cmake/help/latest/module/FindCUDA.html

- 3.8: Support by the Makefile Generators and the Ninja generator on Linux, macOS, and Windows See https://cmake.org/cmake/help/latest/release/3.8.html#cuda\

- 3.9: Support by the Visual Studio Generators for VS 2010 and above. See https://cmake.org/cmake/help/latest/release/3.9.html#languages

- 3.17: Introduction of FindCUDAToolkit See https://cmake.org/cmake/help/latest/release/3.17.html#modules and https://cmake.org/cmake/help/latest/module/FindCUDAToolkit.html#module:FindCUDAToolkit

- 3.18: A CMAKE_CUDA_ARCHITECTURES variable was added to specify CUDA output architectures. See https://cmake.org/cmake/help/latest/release/3.18.html#variables and https://cmake.org/cmake/help/latest/policy/CMP0104.html#policy:CMP0104

- 3.19: If CUDA compiler detection fails with user-specified CMAKE_CUDA_ARCHITECTURES or CMAKE_CUDA_HOST_COMPILER, an error is raised. See https://cmake.org/cmake/help/latest/release/3.19.html#other-changes

- 3.20: The CUDAARCHS environment variable was added for initializing CMAKE_CUDA_ARCHITECTURES. Useful in cases where the compiler default is unsuitable for the machine's GPU. See https://cmake.org/cmake/help/latest/release/3.20.html#languages

- 3.23: The CMAKE_CUDA_ARCHITECTURES variable and associated CUDA_ARCHITECTURES target property now support the all, and all-major values for CUDA toolkit 7.0+. See https://cmake.org/cmake/help/latest/release/3.23.html#variables

List of Autoscoper changes:

```
$ git shortlog 7df4365..22b1a41e0 --no-merges
Jean-Christophe Fillion-Robin (4):
      COMP: Update minimum CMake version from 3.8 to 3.17.5
      COMP: Modernize CUDA integration using FindCUDAToolkit CMake module
      COMP: Update minimum CMake version from 3.17.5 to 3.20.6
      COMP: Initialize list of CUDA architectures for maximum compatibility
```