### PR TITLE
ENH: Update Autoscoper with Quaternion support

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -35,7 +35,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "22b1a41e0b7b6a2de330f436d8834d1a0b96a3ac"
+    "4d2eec33f2e60ad4e81031832915891c690862db"
     QUIET
   )
 


### PR DESCRIPTION
In addition of UI fix related to volume selection, it also fixes the use of the "delete" key for removing a pose on a frame.

List of Autoscoper changes:

```
$ git shortlog 22b1a41e0..4d2eec33f --no-merges
Anthony Lombardi (3):
      BUG: Fix Volume item selection area
      ENH: Reenable original delete functionality
      ENH: Update interpolation to use Quaternions rather than eulers (#255)

Jean-Christophe Fillion-Robin (7):
      STYLE: Remove redundant header guard from "Socket.h"
      STYLE: Improve C++ source files formatting using uncrustify
      ENH: Add clang-format configuration & associated exceptions
      STYLE: Consistent formatting of C++ sources using clang-format
      ENH: Update pre-commit config to include "clang-format"
      STYLE: Ignore source files formatting changes in blame history
      STYLE: Cleanup clang-format configuration files
```