### PR TITLE
COMP: Fix Linux build with Autoscoper CUDA backend enabled

### DIFF
--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -35,7 +35,7 @@ if(DEFINED ENV{SlicerAutoscoperM_CUDA_PATH})
     endif()
   else()
     # See https://cmake.org/cmake/help/latest/envvar/CUDACXX.html#cudacxx
-    set(ENV{CUDACXX} $ENV{_cuda_path}/bin/nvcc)
+    set(ENV{CUDACXX} ${_cuda_path}/bin/nvcc)
   endif()
 endif()
 

--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -35,7 +35,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "4d2eec33f2e60ad4e81031832915891c690862db"
+    "cebc017fe182f0a9e8292eaeb4a2fb173bc52af2"
     QUIET
   )
 


### PR DESCRIPTION
Ensure `CUDACXX` env. var is properly set and also update Autoscoper to ensure the corresponding compiler is found within the Autoscoper inner build.

Follow-up of f732df9 ("ENH: Update Autoscoper modernizing CUDA integration", 2024-02-12)

List of Autoscoper changes:

```
$ git shortlog 4d2eec33f..cebc017fe --no-merges
Jean-Christophe Fillion-Robin (1):
      COMP: Ensure Autoscoper inner-build is built with expected CUDA compiler on Linux

```