### PR TITLE
ENH: Reorganize the pre-processing UI and add PV confirmation

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -426,6 +426,15 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         """
         This function creates partial volumes for each segment in the segmentation node for the selected volume node.
         """
+        if not slicer.util.confirmOkCancelDisplay(
+            "If you plan to run automatic camera placement, ensure you have completed the VRG generation"
+            " before creating partial volumes.\n\n"
+            "Failure to do so will cause the exported TRA files to be misaligned in Autoscoper.\n\n"
+            "Click 'OK' to proceed with partial volume generation.\n"
+            "Click 'Cancel' to stop the process.\n",
+            dontShowAgainSettingsKey="AutoscoperM/DontShowPartialVolumesGenerationWarning",
+        ):
+            return
         with slicer.util.tryWithErrorDisplay("Failed to compute results", waitCursor=True):
             volumeNode = self.ui.volumeSelector.currentNode()
             mainOutputDir = self.ui.mainOutputSelector.currentPath

--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -445,6 +445,57 @@
         </widget>
        </item>
        <item>
+        <widget class="ctkCollapsibleButton" name="TiffGen">
+         <property name="text">
+          <string>Partial Volume Generation</string>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="1" column="1" colspan="2">
+           <widget class="qMRMLNodeComboBox" name="pv_SegNodeComboBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="nodeTypes">
+             <stringlist notr="true">
+              <string>vtkMRMLSegmentationNode</string>
+             </stringlist>
+            </property>
+            <property name="hideChildNodeTypes">
+             <stringlist notr="true"/>
+            </property>
+            <property name="interactionNodeSingletonTag">
+             <string notr="true"/>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Segmentation Node:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="QPushButton" name="tiffGenButton">
+            <property name="text">
+             <string>Generate Partial Volumes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="3">
+           <widget class="QPushButton" name="loadPVButton">
+            <property name="text">
+             <string>Load Partial Volumes</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="ctkCollapsibleButton" name="CollapsibleButton_2">
          <property name="text">
           <string>VRG Generation - Manual Camera Placement</string>
@@ -649,57 +700,6 @@
             </property>
             <property name="value">
              <number>2</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="ctkCollapsibleButton" name="TiffGen">
-         <property name="text">
-          <string>Partial Volume Generation</string>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="1" colspan="2">
-           <widget class="qMRMLNodeComboBox" name="pv_SegNodeComboBox">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="nodeTypes">
-             <stringlist notr="true">
-              <string>vtkMRMLSegmentationNode</string>
-             </stringlist>
-            </property>
-            <property name="hideChildNodeTypes">
-             <stringlist notr="true"/>
-            </property>
-            <property name="interactionNodeSingletonTag">
-             <string notr="true"/>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Segmentation Node:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="3">
-           <widget class="QPushButton" name="tiffGenButton">
-            <property name="text">
-             <string>Generate Partial Volumes</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="3">
-           <widget class="QPushButton" name="loadPVButton">
-            <property name="text">
-             <string>Load Partial Volumes</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
First of two PRs to address #107 

### Re-organize "Pre-processing" tab

This pull request update the "Pre-processing" tab by moving the "Partial Volume Generation" section the "VRG Generation" ones.

| Before | After |
|--|--|
| ![image](https://github.com/BrownBiomechanics/SlicerAutoscoperM/assets/219043/eb53518b-f79c-4ef0-8c95-08b70bf21958) | ![image](https://github.com/BrownBiomechanics/SlicerAutoscoperM/assets/219043/df6e2c92-dce2-47e3-8a89-5efe5d1f45a9) |

### Add warning dialog related to "VRG Generation - Automatic Camera Placement"

As well as adds a dialog box to ensure the user is aware that they have to run "VRG Generation - Automatic Camera Placement" before the "Partial Volume Generation" if that is the pipeline they wish to run
![image](https://github.com/BrownBiomechanics/SlicerAutoscoperM/assets/30351234/03b83ee5-d74f-4726-838f-cb00d25c610d)




