### PR TITLE
WIP: Threadpool Bug

### DIFF
--- a/VirtualRadiographGeneration/VirtualRadiographGeneration.py
+++ b/VirtualRadiographGeneration/VirtualRadiographGeneration.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python-real
 
-import concurrent.futures as cf
 import glob
 import json
 import os
@@ -156,13 +155,5 @@ if __name__ == "__main__":
     reader.SetFileName(volumeData)
     reader.Update()
 
-    # generate the virtual radiograph
-    with cf.ThreadPoolExecutor() as executor:
-        futures = [
-            executor.submit(
-                generateVRG, cam, reader.GetOutput(), os.path.join(camDir, outputFileName), outputWidth, outputHeight
-            )
-            for cam, camDir in cameras.items()
-        ]
-        for future in cf.as_completed(futures):
-            future.result()
+    for cam, camDir in cameras.items():
+        generateVRG(cam, reader.GetOutput(), os.path.join(camDir, outputFileName), outputWidth, outputHeight)


### PR DESCRIPTION
A weird error happening inconsistently for me during the VRG gen. Seems to be related to the ThreadPool, as removing that solves the issue.

```bash
C:/D/S5.5R/python-install/bin/python.exe C:/Users/anthony.lombardi/Projects/SAM/threadpool-bug/lib/Slicer-5.5/cli-modules/Release/VirtualRadiographGeneration.py C:/Users/anthony.lombardi/AppData/Local/Temp/Slicer\AutoscoperM_VRG_GEN_TEMP.mhd C:/Users/anthony.lombardi/AppData/Local/slicer.org/Slicer/cache/SlicerIO\AutoscoperM-Pre-Processing\Calibration C:/Users/anthony.lombardi/AppData/Local/slicer.org/Slicer/cache/SlicerIO\AutoscoperM-Pre-Processing\VRG-Temp 002_3_abduction.tif 1760 1760


VirtualRadiographGeneration terminated with a fault
``` 