### PR TITLE
ENH: Update Autoscoper

### DIFF
--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -35,7 +35,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "8fe9748ab0680955a8c18015009eff0cb457e29a"
+    "8bb1c4e07430dcc53c9771582b97f3bbb9ed2347"
     QUIET
   )
 


### PR DESCRIPTION
Includes the following improvements and fixes:
* https://github.com/BrownBiomechanics/Autoscoper/pull/298
* https://github.com/BrownBiomechanics/Autoscoper/pull/283
* https://github.com/BrownBiomechanics/Autoscoper/pull/292
* https://github.com/BrownBiomechanics/Autoscoper/pull/293
* https://github.com/BrownBiomechanics/Autoscoper/pull/294
* https://github.com/BrownBiomechanics/Autoscoper/pull/296
* https://github.com/BrownBiomechanics/Autoscoper/pull/291


Also includes the following infrastructure fix:
* https://github.com/BrownBiomechanics/Autoscoper/pull/297

List of Autoscoper changes:

```
$ git shortlog 8fe9748ab..8bb1c4e07 --no-merges
Anthony Lombardi (15):
      ENH: Add toggle radiograph shortcut
      DOC: Update shortcuts.md with radiograph toggle
      BUG: Add missing conversion from quaternion to eulers in getPose (#296)
      BUG: Ensure UI visualization is updated when setPose is called
      ENH: Support DRR manipulation with arrow keys
      DOC: Update shortcuts.md with arrow keys
      COMP: Remove empty KeyCurve implementation file
      ENH: Support loading and swapping between multiple tracking files
      DOC: Update shortcuts.md to include tracking file swap keys
      ENH: Add disaply to UI to show number of active tracking sets
      BUG: Fix tab order in tracking options dialog ui file
      DOC: Add glossary of terms to the `Getting Started` page
      ENH: Add shortcut to snap pivot back to COM of the PVOL
      ENH: Add short to align pivot with global axes
      DOC: Add shortcuts O and P to docs

Jean-Christophe Fillion-Robin (4):
      ENH: Update pre-commit settings adding "mixed-line-ending"
      STYLE: Ensure source files line ending is consistent
      ENH: Update pre-commit settings adding "end-of-file-fixer"
      ENH: Simplify VolumeDescription API by removing Vec3f method

```