### PR TITLE
BUG: Fix wrong transformation layers applied to generated PVs

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -769,9 +769,20 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 return
 
             for i in range(len(vols)):
+                nodeName = os.path.splitext(os.path.basename(vols[i]))[0]
                 volumeNode = slicer.util.loadVolume(vols[i])
-                translationNode = slicer.util.loadTransform(tfms_t[i])
-                scaleNode = slicer.util.loadTransform(tfms_scale[i])
+                translationNodeName = os.path.join(mainOutputDir, transformSubDir, f"{nodeName}_t.tfm")
+                scaleNodeName = os.path.join(mainOutputDir, transformSubDir, f"{nodeName}_scale.tfm")
+                if not os.path.exists(translationNodeName):
+                    raise ValueError(
+                        f"Did not find corresponding translation transform for volume {nodeName}: {translationNodeName}"
+                    )
+                if not os.path.exists(scaleNodeName):
+                    raise ValueError(
+                        f"Did not find corresponding scaling transform for volume {nodeName}: {scaleNodeName}"
+                    )
+                translationNode = slicer.util.loadTransform(translationNodeName)
+                scaleNode = slicer.util.loadTransform(scaleNodeName)
 
                 volumeNode.SetAndObserveTransformNodeID(scaleNode.GetID())
                 scaleNode.SetAndObserveTransformNodeID(translationNode.GetID())

--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -771,18 +771,20 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             for i in range(len(vols)):
                 nodeName = os.path.splitext(os.path.basename(vols[i]))[0]
                 volumeNode = slicer.util.loadVolume(vols[i])
-                translationNodeName = os.path.join(mainOutputDir, transformSubDir, f"{nodeName}_t.tfm")
-                scaleNodeName = os.path.join(mainOutputDir, transformSubDir, f"{nodeName}_scale.tfm")
-                if not os.path.exists(translationNodeName):
+                translationTransformFileName = os.path.join(mainOutputDir, transformSubDir, f"{nodeName}_t.tfm")
+                scaleTranformFileName = os.path.join(mainOutputDir, transformSubDir, f"{nodeName}_scale.tfm")
+                if not os.path.exists(translationTransformFileName):
                     raise ValueError(
-                        f"Did not find corresponding translation transform for volume {nodeName}: {translationNodeName}"
+                        f"Failed to load partial volume {nodeName}: "
+                        "Corresponding translation transform file {translationTransformFileName} not found"
                     )
-                if not os.path.exists(scaleNodeName):
+                if not os.path.exists(scaleTranformFileName):
                     raise ValueError(
-                        f"Did not find corresponding scaling transform for volume {nodeName}: {scaleNodeName}"
+                        f"Failed to load partial volume {nodeName}: "
+                        "Corresponding scaling transform file {scaleTranformFileName} not found"
                     )
-                translationNode = slicer.util.loadTransform(translationNodeName)
-                scaleNode = slicer.util.loadTransform(scaleNodeName)
+                translationNode = slicer.util.loadTransform(translationTransformFileName)
+                scaleNode = slicer.util.loadTransform(scaleTranformFileName)
 
                 volumeNode.SetAndObserveTransformNodeID(scaleNode.GetID())
                 scaleNode.SetAndObserveTransformNodeID(translationNode.GetID())


### PR DESCRIPTION
At the end of the partial volume generation process, our approach for matching the generated `*_t.tfm` and `*_scale.tfm` transforms to their corresponding `*.tif` partial volume incorrectly relied on the order of the files as found by `glob`.

The order of items returned by the function cannot be relied upon according to the [docs](https://docs.python.org/3/library/glob.html#glob.glob), so the index of each segment's corresponding volume and transforms in the lists `vols`, `tfms_t` and `tfms_scale` were not guaranteed to be the same. It sometimes resulted in the volume nodes being rendered with the wrong transforms applied to them when volume generation was finished.

Example: when trying to generate PVs from the the segments called `Segment_1` and `Segment_11` (running on Windows),
![Screenshot 2024-10-23 140126](https://github.com/user-attachments/assets/2a6179ce-7774-4e31-8b37-b68d83611113)
Each of the generated PVs have the other's transforms automatically applied to it, so they both don't line up with the original volume:
![Screenshot 2024-10-23 140208](https://github.com/user-attachments/assets/10e3ba48-767c-44ce-bdf5-6466a57e73ae)
![Screenshot 2024-10-23 140217](https://github.com/user-attachments/assets/0f5fd1c4-085a-4796-bf53-fb7c34c390f1)
However, manually swapping the transforms being applied to match the name of their segment seems to solve it:
![Screenshot 2024-10-23 140302](https://github.com/user-attachments/assets/a4cfb904-d689-4b94-aa9b-b833060102dc)
![Screenshot 2024-10-23 140310](https://github.com/user-attachments/assets/3009a2e5-8af7-49b8-83d6-d95afa6e0186)



The code now specifically looks for the correct transforms corresponding to the volume according to the node name instead of relying on the order of the lists given by `glob`.