### PR TITLE
ENH: Update Pre-Processing UI to improve BVR workflow

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -214,8 +214,8 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.volumeSelector.connect("currentNodeChanged(vtkMRMLNode*)", self.onCurrentNodeChanged)
         self.ui.tiffGenButton.connect("clicked(bool)", self.onGeneratePartialVolumes)
         self.ui.configGenButton.connect("clicked(bool)", self.onGenerateConfig)
-        self.ui.segmentationButton.connect("clicked(bool)", self.onSegmentation)
-        self.ui.importModelsButton.connect("clicked(bool)", self.onImportModels)
+        self.ui.segGen_segmentationButton.connect("clicked(bool)", self.onSegmentation)
+        self.ui.segSTL_importModelsButton.connect("clicked(bool)", self.onImportModels)
         self.ui.loadPVButton.connect("clicked(bool)", self.onLoadPV)
         self.ui.populateTrialNameListButton.connect("clicked(bool)", self.onPopulateTrialNameList)
         self.ui.populatePartialVolumeListButton.connect("clicked(bool)", self.onPopulatePartialVolumeList)
@@ -489,7 +489,7 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             configPath = os.path.join(mainOutputDir, f"{configFileName}.cfg")
 
             tiffSubDir = self.ui.tiffSubDir.text
-            vrgSubDir = self.ui.vrgSubDir.text
+            radiographSubDir = self.ui.radiographSubDir.text
             calibrationSubDir = self.ui.cameraSubDir.text
 
             trialList = self.ui.trialList
@@ -502,7 +502,7 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 mainOutputDir=mainOutputDir,
                 configFileName=configFileName,
                 tiffSubDir=tiffSubDir,
-                vrgSubDir=vrgSubDir,
+                radiographSubDir=radiographSubDir,
                 calibrationSubDir=calibrationSubDir,
                 trialList=trialList,
                 partialVolumeList=partialVolumeList,
@@ -513,7 +513,7 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             if not self.logic.validatePaths(
                 mainOutputDir=mainOutputDir,
                 tiffDir=os.path.join(mainOutputDir, tiffSubDir),
-                vrgDir=os.path.join(mainOutputDir, vrgSubDir),
+                radiographSubDir=os.path.join(mainOutputDir, radiographSubDir),
                 calibDir=os.path.join(mainOutputDir, calibrationSubDir),
             ):
                 raise ValueError("Invalid paths")
@@ -530,7 +530,7 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
             # extract filenames from UI lists, and use them to construct the paths relative to mainOutputDir
             # FIXME: don't assume the list of camera files is given in the same order as list of radiograph root dir!
             camCalFiles = [os.path.join(calibrationSubDir, item) for item in get_checked_items(camCalList)]
-            trialDirs = [os.path.join(vrgSubDir, item) for item in get_checked_items(trialList)]
+            trialDirs = [os.path.join(radiographSubDir, item) for item in get_checked_items(trialList)]
 
             if len(camCalFiles) != len(trialDirs):
                 raise ValueError(
@@ -615,8 +615,8 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                 raise ValueError("Invalid inputs")
                 return
 
-            if self.ui.segGen_fileRadioButton.isChecked():
-                segmentationFileDir = self.ui.segGen_lineEdit.currentPath
+            if self.ui.segSTL_loadRadioButton.isChecked():
+                segmentationFileDir = self.ui.segSTL_modelsDir.currentPath
                 if not self.logic.validatePaths(segmentationFileDir=segmentationFileDir):
                     raise ValueError("Invalid paths")
                     return
@@ -663,7 +663,7 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
                     self.logic.cleanFilename(currentVolumeNode.GetName(), i)
                     segmentationNode = SubVolumeExtraction.automaticSegmentation(
                         currentVolumeNode,
-                        self.ui.segGen_ThresholdSpinBox.value,
+                        self.ui.segGen_thresholdSpinBox.value,
                         self.ui.segGen_marginSizeSpin.value,
                         progressCallback=self.updateProgressBar,
                     )
@@ -750,7 +750,7 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         Populates trial name UI list using files from the selected radiograph directory
         """
         with slicer.util.tryWithErrorDisplay("Failed to compute results.", waitCursor=True):
-            self.populateListFromOutputSubDir(self.ui.trialList, self.ui.vrgSubDir.text, itemType="dir")
+            self.populateListFromOutputSubDir(self.ui.trialList, self.ui.radiographSubDir.text, itemType="dir")
 
     def onPopulatePartialVolumeList(self):
         """

--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -9,7 +9,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>811</width>
+    <width>659</width>
     <height>1566</height>
    </rect>
   </property>
@@ -497,85 +497,212 @@
          </property>
          <layout class="QGridLayout" name="configInputs">
           <item row="0" column="0">
-           <layout class="QGridLayout" name="configPaths">
+           <layout class="QGridLayout" name="configName">
             <item row="0" column="0">
              <widget class="QLabel" name="trialNameListLabel">
-              <property name="enabled">
-               <bool>true</bool>
-              </property>
               <property name="text">
-               <string>Select Trial Names:</string>
+               <string>Config Trial Name:</string>
               </property>
              </widget>
             </item>
-            <item row="0" column="1" rowspan="2">
-             <widget class="QListWidget" name="trialList"/>
-            </item>
-            <item row="0" column="2" rowspan="2">
-             <widget class="QLabel" name="configFileNameLabel">
-              <property name="text">
-               <string>and enter :</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="3" rowspan="2">
+            <item row="0" column="1">
              <widget class="QLineEdit" name="configFileName">
               <property name="enabled">
                <bool>true</bool>
               </property>
              </widget>
             </item>
-            <item row="0" column="4" rowspan="2">
+            <item row="0" column="2">
              <widget class="QLabel" name="configFileExtensionLabel">
               <property name="text">
                <string>.cfg</string>
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QPushButton" name="populateTrialNameListButton">
-              <property name="text">
-               <string>Populate From Radiographs Subdirectory</string>
+           </layout>
+          </item>
+          <item row="1" column="0">
+           <layout class="QGridLayout" name="configPaths">
+            <item row="0" column="0">
+             <spacer name="verticalSpacerPVList">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
               </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="partialVolumeListLabel">
-              <property name="text">
-               <string>Select Partial Volumes:</string>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
               </property>
-             </widget>
-            </item>
-            <item row="2" column="1" rowspan="2">
-             <widget class="QListWidget" name="partialVolumeList"/>
-            </item>
-            <item row="3" column="0">
-             <widget class="QPushButton" name="populatePartialVolumeListButton">
-              <property name="text">
-               <string>Populate From Volume Subdirectory</string>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>10</height>
+               </size>
               </property>
-             </widget>
+             </spacer>
             </item>
-            <item row="4" column="0">
+            <item row="1" column="0" colspan="5">
              <widget class="QLabel" name="camCalListLabel">
               <property name="text">
-               <string>Select Camera Calibrations: </string>
+               <string>Select Paired Camera Calibrations: </string>
               </property>
              </widget>
             </item>
-            <item row="4" column="1" rowspan="2">
+            <item row="2" column="0" rowspan="2" colspan="2">
+             <widget class="QListWidget" name="camCalCandidateList">
+              <property name="styleSheet">
+               <string notr="true">
+                QListWidget::indicator:unchecked {
+                 background-color: palette(alternate-base);
+                }
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2" rowspan="3">
+             <widget class="QPushButton" name="stageCameraCalFileButton">
+              <property name="text">
+               <string/>
+              </property>
+              <property name="toolTip">
+               <string>Add selected camera calibration file as next in order</string>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>40</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="3" colspan="2" rowspan="3">
              <widget class="QListWidget" name="camCalList"/>
             </item>
-            <item row="5" column="0">
+            <item row="4" column="0" colspan="2">
              <widget class="QPushButton" name="populateCameraCalListButton">
               <property name="text">
                <string>Populate From Camera Subdirectory</string>
               </property>
              </widget>
             </item>
+            <item row="5" column="0">
+             <spacer name="verticalSpacerCamCalList">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="6" column="0" colspan="5">
+             <widget class="QLabel" name="trialNameListLabel">
+              <property name="text">
+               <string>Select Paired Radiograph Subirectories:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="0" colspan="2" rowspan="2">
+             <widget class="QListWidget" name="trialCandidateList">
+              <property name="styleSheet">
+               <string notr="true">
+                QListWidget::indicator:unchecked {
+                 background-color: palette(alternate-base);
+                }
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="2" rowspan="3">
+             <widget class="QPushButton" name="stageTrialDirButton">
+              <property name="text">
+               <string/>
+              </property>
+              <property name="toolTip">
+               <string>Add selected radiograph subdirectory as next in order</string>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>40</width>
+                <height>16777215</height>
+               </size>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="3" colspan="2" rowspan="3">
+             <widget class="QListWidget" name="trialList"/>
+            </item>
+            <item row="9" column="0" colspan="2">
+             <widget class="QPushButton" name="populateTrialNameListButton">
+              <property name="text">
+               <string>Populate From Radiographs Subdirectory</string>
+              </property>
+             </widget>
+            </item>
+            <item row="10" column="0">
+             <spacer name="verticalSpacerTrialList">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="11" column="0">
+             <widget class="QLabel" name="partialVolumeListLabel">
+              <property name="text">
+               <string>Select Partial Volumes:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="11" column="1" colspan="4" rowspan="2">
+             <widget class="QListWidget" name="partialVolumeList">
+              <property name="styleSheet">
+               <string notr="true">
+                QListWidget::indicator:unchecked {
+                 background-color: palette(alternate-base);
+                }
+               </string>
+              </property>
+             </widget>
+            </item>
+            <item row="13" column="1" colspan="4">
+             <widget class="QPushButton" name="populatePartialVolumeListButton">
+              <property name="text">
+               <string>Populate From Volume Subdirectory</string>
+              </property>
+             </widget>
+            </item>
+            <item row="14" column="0">
+             <spacer name="verticalSpacerPVList">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
            </layout>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <layout class="QGridLayout" name="configParams">
             <item row="0" column="0">
              <widget class="QLabel" name="optOffLabel">

--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1018</width>
-    <height>860</height>
+    <width>811</width>
+    <height>1566</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -120,6 +120,13 @@
          </layout>
         </widget>
        </item>
+       <item>
+        <spacer name="autoscoperControlVerticalLayoutSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="PreprocessingTab">
@@ -128,218 +135,58 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
-        <widget class="ctkCollapsibleButton" name="GeneralInput">
-         <property name="text">
-          <string>General Input</string>
+        <widget class="QProgressBar" name="progressBar">
+         <property name="value">
+          <number>0</number>
          </property>
-         <property name="checked">
-          <bool>true</bool>
+         <property name="invertedAppearance">
+          <bool>false</bool>
          </property>
-         <layout class="QFormLayout" name="formLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Volume Node:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="qMRMLNodeComboBox" name="volumeSelector">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="nodeTypes">
-             <stringlist notr="true">
-              <string>vtkMRMLScalarVolumeNode</string>
-              <string>vtkMRMLSequenceNode</string>
-             </stringlist>
-            </property>
-            <property name="hideChildNodeTypes">
-             <stringlist notr="true"/>
-            </property>
-            <property name="interactionNodeSingletonTag">
-             <string notr="true"/>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Output Directory:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="ctkPathLineEdit" name="mainOutputSelector">
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs|ctkPathLineEdit::Executable|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Writable</set>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_6">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Trial Name:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="trialName">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="2">
-           <widget class="ctkCollapsibleGroupBox" name="AdvancedOptions">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="title">
-             <string>Advanced Options</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-            <property name="collapsed">
-             <bool>false</bool>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_3">
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_14">
-               <property name="text">
-                <string>Camera Subdirectory:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_13">
-               <property name="text">
-                <string>Radiograph Subdirectory:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="2" colspan="2">
-              <widget class="QLineEdit" name="cameraSubDir">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Calibration</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="label_18">
-               <property name="text">
-                <string>Tracking Subdirectory:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="label_15">
-               <property name="text">
-                <string>VRG Resolution: (width,height)</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="2" colspan="2">
-              <widget class="QLineEdit" name="tfmSubDir">
-               <property name="text">
-                <string>Transforms</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="2" colspan="2">
-              <widget class="QLineEdit" name="tiffSubDir">
-               <property name="text">
-                <string>Volumes</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="2">
-              <widget class="QSpinBox" name="vrgRes_width">
-               <property name="maximum">
-                <number>999999999</number>
-               </property>
-               <property name="value">
-                <number>1760</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_20">
-               <property name="text">
-                <string>Partial Volume Transforms Subdirectory:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="2" colspan="2">
-              <widget class="QLineEdit" name="vrgSubDir">
-               <property name="text">
-                <string>RadiographImages</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="3">
-              <widget class="QSpinBox" name="vrgRes_height">
-               <property name="maximum">
-                <number>999999999</number>
-               </property>
-               <property name="value">
-                <number>1760</number>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_12">
-               <property name="text">
-                <string>Partial Volume Subdirectory:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="label_21">
-               <property name="text">
-                <string>Model Subdirectory:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="2" colspan="2">
-              <widget class="QLineEdit" name="trackingSubDir">
-               <property name="text">
-                <string>Tracking</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="2" colspan="2">
-              <widget class="QLineEdit" name="modelSubDir">
-               <property name="text">
-                <string>Models</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QProgressBar" name="progressBar">
-            <property name="value">
-             <number>0</number>
-            </property>
-            <property name="invertedAppearance">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
         </widget>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Output Directory:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="ctkPathLineEdit" name="mainOutputSelector">
+           <property name="filters">
+            <set>ctkPathLineEdit::Dirs|ctkPathLineEdit::Executable|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Writable</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Volume Node:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="qMRMLNodeComboBox" name="volumeSelector">
+           <property name="enabled">
+            <bool>true</bool>
+           </property>
+           <property name="nodeTypes">
+            <stringlist notr="true">
+             <string>vtkMRMLScalarVolumeNode</string>
+             <string>vtkMRMLSequenceNode</string>
+            </stringlist>
+           </property>
+           <property name="hideChildNodeTypes">
+            <stringlist notr="true"/>
+           </property>
+           <property name="interactionNodeSingletonTag">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item>
         <widget class="ctkCollapsibleButton" name="segGen">
@@ -347,16 +194,12 @@
           <string>Segmentation Generation</string>
          </property>
          <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="collapsed">
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Threshold Value:</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QRadioButton" name="segGen_autoRadioButton">
             <property name="text">
@@ -368,23 +211,13 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QRadioButton" name="segGen_fileRadioButton">
+           <widget class="QLabel" name="segThresholdLabel">
             <property name="text">
-             <string>Batch Load from File</string>
+             <string>Threshold Value:</string>
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
-           <widget class="ctkPathLineEdit" name="segGen_lineEdit">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="filters">
-             <set>ctkPathLineEdit::Dirs|ctkPathLineEdit::Drives|ctkPathLineEdit::Executable|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Readable</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
+          <item row="0" column="2">
            <widget class="QSpinBox" name="segGen_ThresholdSpinBox">
             <property name="maximum">
              <number>10000</number>
@@ -394,31 +227,68 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
-           <widget class="QLabel" name="label_10">
+          <item row="1" column="1">
+           <widget class="QLabel" name="segMarginSizeLabel">
             <property name="text">
-             <string>Segmentation File Directory:</string>
+             <string>Margin Size:</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="2">
+          <item row="1" column="2">
+           <widget class="QDoubleSpinBox" name="segGen_marginSizeSpin">
+            <property name="value">
+             <double>2.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="3" rowspan="2">
            <widget class="QPushButton" name="segmentationButton">
             <property name="text">
              <string>Generate Segmentations</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_19">
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Margin Size:</string>
+             <string>OR</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="segGen_fileRadioButton">
+            <property name="text">
+             <string>Segmentation from Model</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="segGen_marginSizeSpin">
-            <property name="value">
-             <double>2.000000000000000</double>
+           <widget class="QLabel" name="segSTLModelsDirLabel">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>STL Models Directory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="ctkPathLineEdit" name="segGen_lineEdit">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="filters">
+             <set>ctkPathLineEdit::Dirs|ctkPathLineEdit::Drives|ctkPathLineEdit::Executable|ctkPathLineEdit::NoDot|ctkPathLineEdit::NoDotDot|ctkPathLineEdit::Readable</set>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="3">
+           <widget class="QPushButton" name="importModelsButton">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Import Models</string>
             </property>
            </widget>
           </item>
@@ -431,9 +301,19 @@
           <string>Partial Volume Generation</string>
          </property>
          <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="collapsed">
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Segmentation Node:</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1" colspan="2">
            <widget class="qMRMLNodeComboBox" name="pv_SegNodeComboBox">
             <property name="enabled">
@@ -449,13 +329,6 @@
             </property>
             <property name="interactionNodeSingletonTag">
              <string notr="true"/>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_9">
-            <property name="text">
-             <string>Segmentation Node:</string>
             </property>
            </widget>
           </item>
@@ -477,6 +350,138 @@
         </widget>
        </item>
        <item>
+        <widget class="ctkCollapsibleButton" name="Subdirectories">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string>Default Subdirectories</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+         <property name="collapsed">
+          <bool>true</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_12">
+            <property name="text">
+             <string>Partial Volume Subdirectory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2" colspan="2">
+           <widget class="QLineEdit" name="tiffSubDir">
+            <property name="text">
+             <string>Volumes</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_20">
+            <property name="text">
+             <string>Partial Volume Transforms Subdirectory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2" colspan="2">
+           <widget class="QLineEdit" name="tfmSubDir">
+            <property name="text">
+             <string>Transforms</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Radiograph Subdirectory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2" colspan="2">
+           <widget class="QLineEdit" name="vrgSubDir">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>RadiographImages</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Camera Subdirectory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2" colspan="2">
+           <widget class="QLineEdit" name="cameraSubDir">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Calibration</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_18">
+            <property name="text">
+             <string>Tracking Subdirectory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2" colspan="2">
+           <widget class="QLineEdit" name="trackingSubDir">
+            <property name="text">
+             <string>Tracking</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_21">
+            <property name="text">
+             <string>Model Subdirectory:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="2" colspan="2">
+           <widget class="QLineEdit" name="modelSubDir">
+            <property name="text">
+             <string>Models</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="ctkCollapsibleButton" name="ConfigGen">
          <property name="enabled">
           <bool>true</bool>
@@ -485,139 +490,289 @@
           <string>Generate Config</string>
          </property>
          <property name="checked">
-          <bool>false</bool>
-         </property>
-         <property name="collapsed">
           <bool>true</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout_4">
-          <item row="1" column="4">
-           <widget class="QCheckBox" name="flipY">
-            <property name="text">
-             <string>Flip Y</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QDoubleSpinBox" name="optOffZ">
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="7">
-           <widget class="QPushButton" name="configGenButton">
-            <property name="text">
-             <string>Generate Config File</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="4">
-           <widget class="QDoubleSpinBox" name="optOffYaw">
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QCheckBox" name="flipX">
-            <property name="text">
-             <string>Flip X</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QDoubleSpinBox" name="optOffY">
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="6">
-           <widget class="QDoubleSpinBox" name="optOffRoll">
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="6">
-           <widget class="QCheckBox" name="flipZ">
-            <property name="text">
-             <string>Flip Z</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="optOffX">
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="5">
-           <widget class="QDoubleSpinBox" name="optOffPitch">
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
+         <property name="collapsed">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="configInputs">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_8">
-            <property name="text">
-             <string>Optimization Offsets:</string>
-            </property>
-           </widget>
+           <layout class="QGridLayout" name="configPaths">
+            <item row="0" column="0">
+             <widget class="QLabel" name="trialNameSelectLabel">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="text">
+               <string>Select Trial Names:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QPushButton" name="populateTrialNameListButton">
+              <property name="text">
+               <string>Populate From Radiographs Subdirectory</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1" rowspan="2">
+             <widget class="QListWidget" name="trialList"/>
+            </item>
+            <item row="0" column="2" rowspan="2">
+             <widget class="QLabel" name="label_17">
+              <property name="text">
+               <string>and enter :</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3" rowspan="2">
+             <widget class="QLineEdit" name="configFileName">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="4" rowspan="2">
+             <widget class="QLabel" name="label_22">
+              <property name="text">
+               <string>.cfg</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="selectPVLabel">
+              <property name="text">
+               <string>Select Partial Volumes:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QPushButton" name="populatePartialVolumeListButton">
+              <property name="text">
+               <string>Populate From Volume Subdirectory</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1" rowspan="2">
+             <widget class="QListWidget" name="partialVolumeList"/>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="SelectCamCalLabel">
+              <property name="text">
+               <string>Select Camera Calibrations: </string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QPushButton" name="populateCameraCalListButton">
+              <property name="text">
+               <string>Populate From Camera Subdirectory</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1" rowspan="2">
+             <widget class="QListWidget" name="camCalList"/>
+            </item>
+           </layout>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_11">
-            <property name="text">
-             <string>Volume Flip:</string>
-            </property>
-           </widget>
+           <layout class="QGridLayout" name="configParams">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>Optimization Offsets:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QDoubleSpinBox" name="optOffX">
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QDoubleSpinBox" name="optOffY">
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="QDoubleSpinBox" name="optOffZ">
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="4">
+             <widget class="QDoubleSpinBox" name="optOffYaw">
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="5">
+             <widget class="QDoubleSpinBox" name="optOffPitch">
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="6">
+             <widget class="QDoubleSpinBox" name="optOffRoll">
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_11">
+              <property name="text">
+               <string>Volume Flip:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QCheckBox" name="flipX">
+              <property name="text">
+               <string>Flip X</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="4">
+             <widget class="QCheckBox" name="flipY">
+              <property name="text">
+               <string>Flip Y</string>
+              </property>
+              <property name="checked">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="6">
+             <widget class="QCheckBox" name="flipZ">
+              <property name="text">
+               <string>Flip Z</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_15">
+              <property name="text">
+               <string>Render Resolution: (width,height)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1" colspan="3">
+             <widget class="QSpinBox" name="configRes_width">
+              <property name="maximum">
+               <number>999999999</number>
+              </property>
+              <property name="value">
+               <number>1760</number>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="4" colspan="3">
+             <widget class="QSpinBox" name="configRes_height">
+              <property name="maximum">
+               <number>999999999</number>
+              </property>
+              <property name="value">
+               <number>1760</number>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="label_16">
+              <property name="text">
+               <string>Voxel Size:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1" colspan="2">
+             <widget class="QDoubleSpinBox" name="voxelSizeX">
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="3" colspan="2">
+             <widget class="QDoubleSpinBox" name="voxelSizeY">
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="5" colspan="2">
+             <widget class="QDoubleSpinBox" name="voxelSizeZ">
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="decimals">
+               <number>3</number>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0" colspan="7">
+             <widget class="QPushButton" name="configGenButton">
+              <property name="text">
+               <string>Generate Config File</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
        </item>
+       <item>
+        <spacer name="preprocessingVerticalLayoutSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </widget>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>
@@ -638,17 +793,6 @@
    <extends>QWidget</extends>
    <header>ctkCollapsibleButton.h</header>
    <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>ctkCollapsibleGroupBox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ctkDoubleRangeSlider</class>
-   <extends>QWidget</extends>
-   <header>ctkDoubleRangeSlider.h</header>
   </customwidget>
   <customwidget>
    <class>ctkPathLineEdit</class>
@@ -735,6 +879,86 @@
     <hint type="destinationlabel">
      <x>594</x>
      <y>370</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>segGen_fileRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>importModelsButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>276</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>698</x>
+     <y>204</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>segGen_autoRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>segmentationButton</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>189</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>698</x>
+     <y>276</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>segGen_fileRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>segSTLModelsDirLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>276</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>279</x>
+     <y>276</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>segGen_autoRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>segThresholdLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>189</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>279</x>
+     <y>189</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>segGen_autoRadioButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>segMarginSizeLabel</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>122</x>
+     <y>189</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>279</x>
+     <y>220</y>
     </hint>
    </hints>
   </connection>

--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -147,7 +147,7 @@
        <item>
         <layout class="QFormLayout" name="formLayout">
          <item row="0" column="0">
-          <widget class="QLabel" name="label_5">
+          <widget class="QLabel" name="mainOutputSelectorLabel">
            <property name="text">
             <string>Output Directory:</string>
            </property>
@@ -161,7 +161,7 @@
           </widget>
          </item>
          <item row="1" column="0">
-          <widget class="QLabel" name="label_2">
+          <widget class="QLabel" name="volumeSelectorLabel">
            <property name="text">
             <string>Volume Node:</string>
            </property>
@@ -211,14 +211,14 @@
            </widget>
           </item>
           <item row="0" column="1">
-           <widget class="QLabel" name="segThresholdLabel">
+           <widget class="QLabel" name="segGen_thresholdLabel">
             <property name="text">
              <string>Threshold Value:</string>
             </property>
            </widget>
           </item>
           <item row="0" column="2">
-           <widget class="QSpinBox" name="segGen_ThresholdSpinBox">
+           <widget class="QSpinBox" name="segGen_thresholdSpinBox">
             <property name="maximum">
              <number>10000</number>
             </property>
@@ -227,8 +227,15 @@
             </property>
            </widget>
           </item>
+          <item row="0" column="3" rowspan="2">
+           <widget class="QPushButton" name="segGen_segmentationButton">
+            <property name="text">
+             <string>Generate Segmentations</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
-           <widget class="QLabel" name="segMarginSizeLabel">
+           <widget class="QLabel" name="segGen_marginSizeLabel">
             <property name="text">
              <string>Margin Size:</string>
             </property>
@@ -241,29 +248,22 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="3" rowspan="2">
-           <widget class="QPushButton" name="segmentationButton">
-            <property name="text">
-             <string>Generate Segmentations</string>
-            </property>
-           </widget>
-          </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="seg_OR_Label">
             <property name="text">
              <string>OR</string>
             </property>
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QRadioButton" name="segGen_fileRadioButton">
+           <widget class="QRadioButton" name="segSTL_loadRadioButton">
             <property name="text">
              <string>Segmentation from Model</string>
             </property>
            </widget>
           </item>
           <item row="3" column="1">
-           <widget class="QLabel" name="segSTLModelsDirLabel">
+           <widget class="QLabel" name="segSTL_modelsDirLabel">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -273,7 +273,7 @@
            </widget>
           </item>
           <item row="3" column="2">
-           <widget class="ctkPathLineEdit" name="segGen_lineEdit">
+           <widget class="ctkPathLineEdit" name="segSTL_modelsDir">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -283,7 +283,7 @@
            </widget>
           </item>
           <item row="3" column="3">
-           <widget class="QPushButton" name="importModelsButton">
+           <widget class="QPushButton" name="segSTL_importModelsButton">
             <property name="enabled">
              <bool>false</bool>
             </property>
@@ -307,14 +307,14 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_9">
+          <item row="0" column="0">
+           <widget class="QLabel" name="pv_SegNodeComboBoxLabel">
             <property name="text">
              <string>Segmentation Node:</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1" colspan="2">
+          <item row="0" column="1" colspan="2">
            <widget class="qMRMLNodeComboBox" name="pv_SegNodeComboBox">
             <property name="enabled">
              <bool>true</bool>
@@ -332,14 +332,14 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="3">
+          <item row="1" column="0" colspan="3">
            <widget class="QPushButton" name="tiffGenButton">
             <property name="text">
              <string>Generate Partial Volumes</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="3">
+          <item row="2" column="0" colspan="3">
            <widget class="QPushButton" name="loadPVButton">
             <property name="text">
              <string>Load Partial Volumes</string>
@@ -368,7 +368,7 @@
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
           <item row="0" column="0">
-           <widget class="QLabel" name="label_12">
+           <widget class="QLabel" name="tiffSubDirLabel">
             <property name="text">
              <string>Partial Volume Subdirectory:</string>
             </property>
@@ -382,7 +382,7 @@
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_20">
+           <widget class="QLabel" name="tfmSubDirLabel">
             <property name="text">
              <string>Partial Volume Transforms Subdirectory:</string>
             </property>
@@ -396,7 +396,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_13">
+           <widget class="QLabel" name="radiographSubDirLabel">
             <property name="font">
              <font>
               <weight>75</weight>
@@ -409,7 +409,7 @@
            </widget>
           </item>
           <item row="2" column="2" colspan="2">
-           <widget class="QLineEdit" name="vrgSubDir">
+           <widget class="QLineEdit" name="radiographSubDir">
             <property name="font">
              <font>
               <weight>75</weight>
@@ -422,7 +422,7 @@
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="label_14">
+           <widget class="QLabel" name="cameraSubDirLabel">
             <property name="font">
              <font>
               <weight>75</weight>
@@ -451,7 +451,7 @@
            </widget>
           </item>
           <item row="4" column="0">
-           <widget class="QLabel" name="label_18">
+           <widget class="QLabel" name="trackingSubDirLabel">
             <property name="text">
              <string>Tracking Subdirectory:</string>
             </property>
@@ -465,7 +465,7 @@
            </widget>
           </item>
           <item row="5" column="0">
-           <widget class="QLabel" name="label_21">
+           <widget class="QLabel" name="modelSubDirLabel">
             <property name="text">
              <string>Model Subdirectory:</string>
             </property>
@@ -499,7 +499,7 @@
           <item row="0" column="0">
            <layout class="QGridLayout" name="configPaths">
             <item row="0" column="0">
-             <widget class="QLabel" name="trialNameSelectLabel">
+             <widget class="QLabel" name="trialNameListLabel">
               <property name="enabled">
                <bool>true</bool>
               </property>
@@ -508,18 +508,11 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="0">
-             <widget class="QPushButton" name="populateTrialNameListButton">
-              <property name="text">
-               <string>Populate From Radiographs Subdirectory</string>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="1" rowspan="2">
              <widget class="QListWidget" name="trialList"/>
             </item>
             <item row="0" column="2" rowspan="2">
-             <widget class="QLabel" name="label_17">
+             <widget class="QLabel" name="configFileNameLabel">
               <property name="text">
                <string>and enter :</string>
               </property>
@@ -533,18 +526,28 @@
              </widget>
             </item>
             <item row="0" column="4" rowspan="2">
-             <widget class="QLabel" name="label_22">
+             <widget class="QLabel" name="configFileExtensionLabel">
               <property name="text">
                <string>.cfg</string>
               </property>
              </widget>
             </item>
+            <item row="1" column="0">
+             <widget class="QPushButton" name="populateTrialNameListButton">
+              <property name="text">
+               <string>Populate From Radiographs Subdirectory</string>
+              </property>
+             </widget>
+            </item>
             <item row="2" column="0">
-             <widget class="QLabel" name="selectPVLabel">
+             <widget class="QLabel" name="partialVolumeListLabel">
               <property name="text">
                <string>Select Partial Volumes:</string>
               </property>
              </widget>
+            </item>
+            <item row="2" column="1" rowspan="2">
+             <widget class="QListWidget" name="partialVolumeList"/>
             </item>
             <item row="3" column="0">
              <widget class="QPushButton" name="populatePartialVolumeListButton">
@@ -553,15 +556,15 @@
               </property>
              </widget>
             </item>
-            <item row="2" column="1" rowspan="2">
-             <widget class="QListWidget" name="partialVolumeList"/>
-            </item>
             <item row="4" column="0">
-             <widget class="QLabel" name="SelectCamCalLabel">
+             <widget class="QLabel" name="camCalListLabel">
               <property name="text">
                <string>Select Camera Calibrations: </string>
               </property>
              </widget>
+            </item>
+            <item row="4" column="1" rowspan="2">
+             <widget class="QListWidget" name="camCalList"/>
             </item>
             <item row="5" column="0">
              <widget class="QPushButton" name="populateCameraCalListButton">
@@ -570,15 +573,12 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="1" rowspan="2">
-             <widget class="QListWidget" name="camCalList"/>
-            </item>
            </layout>
           </item>
           <item row="1" column="0">
            <layout class="QGridLayout" name="configParams">
             <item row="0" column="0">
-             <widget class="QLabel" name="label_8">
+             <widget class="QLabel" name="optOffLabel">
               <property name="text">
                <string>Optimization Offsets:</string>
               </property>
@@ -645,7 +645,7 @@
              </widget>
             </item>
             <item row="1" column="0">
-             <widget class="QLabel" name="label_11">
+             <widget class="QLabel" name="flipLabel">
               <property name="text">
                <string>Volume Flip:</string>
               </property>
@@ -679,7 +679,7 @@
              </widget>
             </item>
             <item row="2" column="0">
-             <widget class="QLabel" name="label_15">
+             <widget class="QLabel" name="configResLabel">
               <property name="text">
                <string>Render Resolution: (width,height)</string>
               </property>
@@ -706,7 +706,7 @@
              </widget>
             </item>
             <item row="3" column="0">
-             <widget class="QLabel" name="label_16">
+             <widget class="QLabel" name="voxelSizeLabel">
               <property name="text">
                <string>Voxel Size:</string>
               </property>
@@ -821,7 +821,7 @@
   <connection>
    <sender>segGen_autoRadioButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>segGen_ThresholdSpinBox</receiver>
+   <receiver>segGen_thresholdSpinBox</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -835,9 +835,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>segGen_fileRadioButton</sender>
+   <sender>segSTL_loadRadioButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>segGen_lineEdit</receiver>
+   <receiver>segSTL_modelsDir</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -883,9 +883,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>segGen_fileRadioButton</sender>
+   <sender>segSTL_loadRadioButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>importModelsButton</receiver>
+   <receiver>segSTL_importModelsButton</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -901,7 +901,7 @@
   <connection>
    <sender>segGen_autoRadioButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>segmentationButton</receiver>
+   <receiver>segGen_segmentationButton</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -915,9 +915,9 @@
    </hints>
   </connection>
   <connection>
-   <sender>segGen_fileRadioButton</sender>
+   <sender>segSTL_loadRadioButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>segSTLModelsDirLabel</receiver>
+   <receiver>segSTL_modelsDirLabel</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -933,7 +933,7 @@
   <connection>
    <sender>segGen_autoRadioButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>segThresholdLabel</receiver>
+   <receiver>segGen_thresholdLabel</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -949,7 +949,7 @@
   <connection>
    <sender>segGen_autoRadioButton</sender>
    <signal>toggled(bool)</signal>
-   <receiver>segMarginSizeLabel</receiver>
+   <receiver>segGen_marginSizeLabel</receiver>
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">


### PR DESCRIPTION
Resolves https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/131, resolves #145.

These changes are aimed to improve the user workflow in the Pre-Processing module, specifically targeting the improvement of the Autoscoper configuration file generation. Further changes to improve error handling to make it more user-friendly are to be continued in a separate upcoming PR.

Changes in this PR include:
* 'Volume Node' and 'Output Directory' at top of UI were swapped
* 'Trial Name' moved to the config generation section as the '<blank>'.cfg field
* The segmentation generation section was redesigned to better convey the two separate generation methods
* The 'Adavnced Options' sections was renamed to 'Default Subdirectories', moved below the 'Segmentation Generation' section, and is now rendered as collapsed by default
* The 'VRG Resolution' fields from 'Advanced Options' was moved to the config generation section
* In the 'Generate Config' section, added file and path selectors to specify the camera calibration files, radiograph root directories, and volume files to be written to the generated config file. Also added 'Voxel Size' fields that are automatically populated based on the selected input volume node.
* Elements in the .ui files were edited to be properly indexed and named

Remaining TODOs:
- [x] Decide and implement correct pairing of radiograph subfolders with their camera calibration files
- [x] Update [the documentation page](https://autoscoper.readthedocs.io/en/latest/tutorials/pre-processing-module.html) --> see https://github.com/BrownBiomechanics/Autoscoper/pull/308

| Existing Pre-Processing UI | New Pre-Processing UI |
| -------------------------- | --------------------- |
| ![image](https://github.com/user-attachments/assets/2a5b8686-7df8-408e-a91b-80d213e2d0e3) | ![image](https://github.com/user-attachments/assets/f1a5751f-a9ce-4e57-978f-53cdc906e1d0) |