### PR TITLE
ENH: Collapse 'Advanced' Pre-Processing menu by default

### DIFF
--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -208,7 +208,7 @@
              <bool>true</bool>
             </property>
             <property name="collapsed">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
              <item row="3" column="0">


### PR DESCRIPTION
Resolves https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/145.

The 'Advanced Options' menu in the Pre-Processing module is still toggleable, but is now rendered as collapsed by default on module launch.