### PR TITLE
BUG: Remove more VRG Generation relics

### DIFF
--- a/AutoscoperM/AutoscoperMLib/IO.py
+++ b/AutoscoperM/AutoscoperMLib/IO.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from itertools import product
 
 import numpy as np
 import slicer
@@ -202,12 +201,3 @@ def writeTFMFile(filename: str, spacing: list[float], origin: list[float]):
     slicer.util.exportNode(transformNode, filename)
 
     slicer.mrmlScene.RemoveNode(transformNode)
-
-
-def writeTRA(fileName: str, transforms: list[vtk.vtkMatrix4x4]) -> None:
-    rowWiseStrings = []
-    for transform in transforms:
-        rowWiseStrings.append([str(transform.GetElement(i, j)) for i, j in product(range(4), range(4))])
-    with open(fileName, "w+") as traFile:
-        for row in rowWiseStrings:
-            traFile.write(",".join(row) + "\n")

--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -462,6 +462,9 @@
             <property name="text">
              <string>Tracking</string>
             </property>
+            <property name="enabled">
+             <bool>False</bool>
+            </property>
            </widget>
           </item>
           <item row="5" column="0">


### PR DESCRIPTION
Resolves https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/160.

The changes follow up on https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/140 to remove the unused function `extractSubVolumeForVRG` as well as all other code associated with the calculation and export of `.tra` files during the generation of partial volumes in the pre-processing module.