### PR TITLE
ENH: Export generated `.stl` files to AUT subfolder

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -1081,7 +1081,7 @@ class AutoscoperMLogic(ScriptedLoadableModuleLogic):
             dicom2autFilename = os.path.join(outputDir, transformSubDir, f"{segmentVolume.GetName()}-DICOM2AUT.tfm")
             slicer.util.exportNode(dicom2autNode, dicom2autFilename)
 
-            stlFilename = os.path.join(outputDir, modelSubDir, f"AUT_{segmentVolume.GetName()}.stl")
+            stlFilename = os.path.join(outputDir, modelSubDir, "AUT", f"AUT_{segmentVolume.GetName()}.stl")
             self.exportSTLFromSegment(segmentationNode, segmentID, stlFilename, dicom2autNode.GetTransformToParent())
 
             slicer.mrmlScene.RemoveNode(dicom2autNode)


### PR DESCRIPTION
Resolves https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/158.

During partial volume generation, `AUT_{bone}.stl` files are now written to `<models subdirectory>/AUT` instead of 
 directly to the models subdirectory. This new user workflow should better help separate models in AUT space, and models in world coordinates the user exports from the Slicer scene.