### PR TITLE
ENH: Update the Wrist sample data

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -110,7 +110,7 @@ def registerAutoscoperSampleData(dataType, version, checksum):
 def sampleDataConfigFile(dataType):
     """Return the trial config filename."""
     return {
-        "2025-01-12-Wrist": "2023-07-20-Wrist.cfg",
+        "2025-02-19-Wrist": "Wrist_Sample_Data.cfg",
         "2025-02-10-Knee": "Knee_Sample_Data.cfg",
         "2025-01-12-Ankle": "2023-07-20-Ankle.cfg",
     }.get(dataType)
@@ -121,7 +121,7 @@ def registerSampleData():
     Add data sets to Sample Data module.
     """
     registerAutoscoperSampleData(
-        "Wrist", "2025-01-12", checksum="SHA256:13eca7b7ddbf3111c433d10871aa5ee7328d056427cdaaf9407038a021ab8326"
+        "Wrist", "2025-02-19", checksum="SHA256:6780bf13107c730d8a07ad7ff0d9f53b250b0c910f2c2c2e94ed021a4547dc19"
     )
     registerAutoscoperSampleData(
         "Knee", "2025-02-10", checksum="SHA256:02442eafc71b7d7ac2e6d57d510fc0d3e2c775db2ea458659142316f004b6af6"
@@ -206,7 +206,7 @@ class AutoscoperMWidget(ScriptedLoadableModuleWidget, VTKObservationMixin):
         self.ui.autoscoperRenderingBackendComboBox.addItems(list(self.autoscoperExecutables.keys()))
 
         # Sample Data Buttons
-        self.ui.wristSampleButton.connect("clicked(bool)", lambda: self.onSampleDataButtonClicked("2025-01-12-Wrist"))
+        self.ui.wristSampleButton.connect("clicked(bool)", lambda: self.onSampleDataButtonClicked("2025-02-19-Wrist"))
         self.ui.kneeSampleButton.connect("clicked(bool)", lambda: self.onSampleDataButtonClicked("2025-02-10-Knee"))
         self.ui.ankleSampleButton.connect("clicked(bool)", lambda: self.onSampleDataButtonClicked("2025-01-12-Ankle"))
 

--- a/TrackingEvaluation/TrackingEvaluation.py
+++ b/TrackingEvaluation/TrackingEvaluation.py
@@ -190,7 +190,7 @@ class TrackingEvaluationWidget(ScriptedLoadableModuleWidget, VTKObservationMixin
         ankleRadio = self.ui.ankleRadioButton.isChecked()
         sampleDataType = ""
         if wristRadio:
-            sampleDataType = "2025-01-12-Wrist"
+            sampleDataType = "2025-02-19-Wrist"
         elif kneeRadio:
             sampleDataType = "2025-02-10-Knee"
         elif ankleRadio:


### PR DESCRIPTION
Addresses [#156](https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/156), incorporates data as provided by @amymmorton in https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/138#issuecomment-2651569270.

As a follow up to https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/159, the Wrist [sample data](https://github.com/BrownBiomechanics/Autoscoper/releases/tag/sample-data) was also updated to rename the `Meshes` folder name to `Models`, include the `.nrrd` source CT data to the `Scene` folder, and add the corresponding partial volume and transform files to the `Volumes` and `Transforms` directories.