### PR TITLE
ENH: Reimplement Hierarchical 3D Registration with ROI cropped volumes

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -1292,9 +1292,7 @@ class AutoscoperMLogic(ScriptedLoadableModuleLogic):
         return dicom2autNode
 
     @staticmethod
-    def getModelBoundingBox(
-        model: slicer.vtkMRMLModelNode
-    ) -> list[float]:
+    def getModelBoundingBox(model: slicer.vtkMRMLModelNode) -> list[float]:
         """Utility function to return the center and size of model node"""
         model_bounds = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         model.GetBounds(model_bounds)
@@ -1357,16 +1355,15 @@ class AutoscoperMLogic(ScriptedLoadableModuleLogic):
         cvpn.SetROINodeID(roiNode.GetID())
         cvpn.SetInputVolumeNodeID(inputVolumeNode.GetID())
         cvpn.SetVoxelBased(True)
-        if outputVolumeNode != None:
+        if outputVolumeNode is not None:
             cvpn.SetOutputVolumeNodeID(outputVolumeNode.GetID())
 
         # apply the cropping
         cropLogic = slicer.modules.cropvolume.logic()
         cropLogic.Apply(cvpn)
 
-        if outputVolumeNode != None:
+        if outputVolumeNode is not None:
             return outputVolumeNode
-        else:
-            outputVolumeNodeID = cvpn.GetOutputVolumeNodeID()
-            outputVolumeNode = slicer.mrmlScene.GetNodeByID(outputVolumeNodeID)
-            return outputVolumeNode
+
+        outputVolumeNodeID = cvpn.GetOutputVolumeNodeID()
+        return slicer.mrmlScene.GetNodeByID(outputVolumeNodeID)

--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -1316,25 +1316,30 @@ class AutoscoperMLogic(ScriptedLoadableModuleLogic):
         """Utility function to check if the bounds of the ROI exceed those of
         the target volume, and if so compute the bounds of their intersection"""
         roi_bounds = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-        vol_bounds = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        volume_bounds = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         roiNode.GetBounds(roi_bounds)
-        volumeNode.GetBounds(vol_bounds)
+        volumeNode.GetBounds(volume_bounds)
 
         # to find intersection of bbs, take the max of the mins and the min of the maxs
         import numpy as np
-        bb_min = np.array([
-            max(roi_bounds[0], vol_bounds[0]),
-            max(roi_bounds[2], vol_bounds[2]),
-            max(roi_bounds[4], vol_bounds[4])
-        ])
-        bb_max = np.array([
-            min(roi_bounds[1], vol_bounds[1]),
-            min(roi_bounds[3], vol_bounds[3]),
-            min(roi_bounds[5], vol_bounds[5])
-        ])
+
+        bb_min = np.array(
+            [
+                max(roi_bounds[0], volume_bounds[0]),
+                max(roi_bounds[2], volume_bounds[2]),
+                max(roi_bounds[4], volume_bounds[4]),
+            ]
+        )
+        bb_max = np.array(
+            [
+                min(roi_bounds[1], volume_bounds[1]),
+                min(roi_bounds[3], volume_bounds[3]),
+                min(roi_bounds[5], volume_bounds[5]),
+            ]
+        )
 
         # check if the bounds of the intersection are different than the original ROI
-        bb_bounds = np.ravel([bb_min, bb_max], 'F')
+        bb_bounds = np.ravel([bb_min, bb_max], "F")
         if np.any(np.abs(bb_bounds - np.array(roi_bounds))):
             # ROI bounds need trimming, so return the new bounds
             bb_center = (bb_min + bb_max) / 2

--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -1290,3 +1290,22 @@ class AutoscoperMLogic(ScriptedLoadableModuleLogic):
         dicom2autNode.SetMatrixTransformToParent(dicom2aut)
         slicer.mrmlScene.AddNode(dicom2autNode)
         return dicom2autNode
+
+    @staticmethod
+    def getModelBoundingBox(
+        model: slicer.vtkMRMLModelNode
+    ) -> list[float]:
+        """Utility function to return the center and size of model node"""
+        model_bounds = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        model.GetBounds(model_bounds)
+
+        import numpy as np
+
+        # construct min and max coordinates of bounding box
+        bb_min = np.array([model_bounds[0], model_bounds[2], model_bounds[4]])
+        bb_max = np.array([model_bounds[1], model_bounds[3], model_bounds[5]])
+
+        bb_center = (bb_min + bb_max) / 2
+        bb_size = bb_min - bb_max
+
+        return bb_center.tolist(), bb_size.tolist()

--- a/AutoscoperM/AutoscoperMLib/IO.py
+++ b/AutoscoperM/AutoscoperMLib/IO.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from itertools import product
 
 import numpy as np
 import slicer
@@ -201,3 +202,12 @@ def writeTFMFile(filename: str, spacing: list[float], origin: list[float]):
     slicer.util.exportNode(transformNode, filename)
 
     slicer.mrmlScene.RemoveNode(transformNode)
+
+
+def writeTRA(fileName: str, transforms: list[vtk.vtkMatrix4x4]) -> None:
+    rowWiseStrings = []
+    for transform in transforms:
+        rowWiseStrings.append([str(transform.GetElement(i, j)) for i, j in product(range(4), range(4))])
+    with open(fileName, "w+") as traFile:
+        for row in rowWiseStrings:
+            traFile.write(",".join(row) + "\n")

--- a/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
+++ b/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
@@ -32,9 +32,12 @@ class TreeNode:
         self.name = self.shNode.GetItemName(self.hierarchyID)
         self.model = self.shNode.GetItemDataNode(self.hierarchyID)
 
+        if self.model.GetClassName() != "vtkMRMLModelNode":
+            raise ValueError(f"Hierarchy item '{self.name}' is not a model!")
+
         self.roi = self._generateRoiFromModel()
         self.transformSequence = self._initializeTransforms(ctSequence)
-        self.croppedCtSequence = self._initializeCroppedCT(ctSequence)
+        self.croppedCtSequence = dict() #self._initializeCroppedCT(ctSequence)
 
         children_ids = []
         self.shNode.GetItemChildren(self.hierarchyID, children_ids)
@@ -43,10 +46,12 @@ class TreeNode:
         ]
 
     def _generateRoiFromModel(self) -> slicer.vtkMRMLMarkupsROINode:
+        """Creates a region of interest node from this TreeNode's model."""
         mBounds = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         self.model.GetBounds(mBounds)
 
         import numpy as np
+
         # construct min and max coordinates of bounding box
         bb_min = np.array([mBounds[0], mBounds[2], mBounds[4]])
         bb_max = np.array([mBounds[1], mBounds[3], mBounds[5]])
@@ -58,20 +63,19 @@ class TreeNode:
         modelROI = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLMarkupsROINode")
         modelROI.SetCenter(bb_center.tolist())
         modelROI.SetSize(bb_size.tolist())
-        #modelROI.CreateDefaultDisplayNodes()  # only needed for display, TODO: hide
-        #modelROI.SetAttribute("Markups.MovingInSliceView", "");
-        #modelROI.SetAttribute("Markups.MovingMarkupIndex", "");
+        modelROI.SetDisplayVisibility(0)
+        # modelROI.CreateDefaultDisplayNodes()  # only needed for display, TODO: hide
+        # modelROI.SetAttribute("Markups.MovingInSliceView", "");
+        # modelROI.SetAttribute("Markups.MovingMarkupIndex", "");
         modelROI.SetName(f"{self.name}_roi")
 
         return modelROI
 
     def _initializeTransforms(self, ctSequence) -> slicer.vtkMRMLSequenceNode:
         """Creates a new transform sequence in the same browser as the CT sequence."""
-        #TODO: make sure output transforms start at the appropriate if startIdx != 0.
+        # TODO: make sure output transforms start at the appropriate if startIdx != 0.
 
-        newSequenceNode = AutoscoperMLogic.createSequenceNodeInBrowser(
-            f"{self.name}_transform_sequence", ctSequence
-        )
+        newSequenceNode = AutoscoperMLogic.createSequenceNodeInBrowser(f"{self.name}_transform_sequence", ctSequence)
         identityTfm = slicer.mrmlScene.CreateNodeByClass("vtkMRMLLinearTransformNode")
 
         # batch the processing event for the addition of the transforms, for speedup
@@ -84,26 +88,36 @@ class TreeNode:
         slicer.mrmlScene.EndState(slicer.vtkMRMLScene.BatchProcessState)
         slicer.app.processEvents()
         return newSequenceNode
+        """
+        nodes = []
+        for i in range(ctSequence.GetNumberOfDataNodes()):
+            curTfm = slicer.mrmlScene.AddNewNodeByClass("vtkMRMLLinearTransformNode", f"{self.name}-{i}")
+            newSequenceNode.SetDataNodeAtValue(curTfm, f"{i}")
+            nodes.append(curTfm)
+        [slicer.mrmlScene.RemoveNode(node) for node in nodes]
+        # Bit of a strange issue but the browser doesn't seem to update unless it moves to a new index,
+        # so we force it to update here
+        AutoscoperMLogic.getItemInSequence(newSequenceNode, 1)
+        AutoscoperMLogic.getItemInSequence(newSequenceNode, 0)
+        slicer.app.processEvents()
+        return newSequenceNode
+        """
 
     def _initializeCroppedCT(self, ctSequence) -> slicer.vtkMRMLSequenceNode:
         """Creates a new (but empty) volume sequence in the same browser as the CT sequence."""
 
-        newSequenceNode = AutoscoperMLogic.createSequenceNodeInBrowser(
-            f"{self.name}_cropped_CT_sequence", ctSequence
-        )
-
-        return newSequenceNode
+        return AutoscoperMLogic.createSequenceNodeInBrowser(f"{self.name}_cropped_CT_sequence", ctSequence)
 
     def setupFrame(self, frameIdx, ctFrame) -> None:
         """
-        TODO description
+        Return a cropped volume from the given CT frame based on the initial guess
+        transform for the given frame and this model's ROI.
         """
-        # prompt user to adjust initial guess, then crop target volume
-        initial_tfm = self.getTransform(frameIdx)  # for root, this will just be the identity
-        self.model.SetAndObserveTransformNodeID(initial_tfm.GetID())
-        #initial_tfm.user_adjust_model() # optionally user adjusts initial guess for this bone in initial frame
+        # TODO: user to manual adjust the initial transform
 
-        # generate cropped volume from frame
+        initial_tfm = self.getTransform(frameIdx)  # for the root node, this will just be the identity
+        # generate cropped volume from the given frame
+        self.model.SetAndObserveTransformNodeID(initial_tfm.GetID())
         self.roi.SetAndObserveTransformNodeID(initial_tfm.GetID())
         self.cropFrameFromRoi(frameIdx, ctFrame)
 
@@ -111,35 +125,35 @@ class TreeNode:
 
     def cropFrameFromRoi(self, frame_idx, targetFrame) -> None:
         """
-        TODO description
+        Returns a cropped volume from the given target volume, based its
+        corresponding initial guess transform and this model's ROI.
+
+        :param frame_idx: the frame index corresponding to the target frame
+        :param targetFrame: the target volume to be cropped from the ROI
+
+        :return: the output cropped volume node
         """
-        outputVolumeNode = self.croppedCtSequence.GetDataNodeAtValue(frame_idx, exactMatchRequired=True)
-        if not outputVolumeNode:
-            # create volume node for the output of the cropping, and add it to the sequence
-            outputVolumeNode = slicer.mrmlScene.CreateNodeByClass("vtkMRMLVolumeNode")
-            #outputVolumeNode.SetName(f"{targetFrame.GetName()}_{self.name}_cropped")
-            self.croppedCtSequence.SetDataNodeAtValue(outputVolumeNode, frame_idx)
+        # create volume node for the output of the cropping, and add it to the sequence
+        #outputVolumeNode = slicer.mrmlScene.CreateNodeByClass("vtkMRMLScalarVolumeNode")
 
-            # initialize croppping configuration
-            cvpn = slicer.vtkMRMLCropVolumeParametersNode()
-            cvpn.SetROINodeID(self.roi.GetID())
-            cvpn.SetInputVolumeNodeID(targetFrame.GetID())
-            cvpn.SetOutputVolumeNodeID(outputVolumeNode.GetID())
-            cvpn.SetVoxelBased(True)
+        # initialize croppping configuration
+        cvpn = slicer.vtkMRMLCropVolumeParametersNode()
+        cvpn.SetROINodeID(self.roi.GetID())
+        cvpn.SetInputVolumeNodeID(targetFrame.GetID())
+        #cvpn.SetOutputVolumeNodeID(outputVolumeNode.GetID())
+        cvpn.SetVoxelBased(True)
 
-            # apply the cropping
-            cropLogic = slicer.modules.cropvolume.logic()
-            cropLogic.Apply(cvpn)
+        # apply the cropping
+        cropLogic = slicer.modules.cropvolume.logic()
+        cropLogic.Apply(cvpn)
 
-            # display pretty:
-            # https://www.slicer.org/wiki/Documentation/4.3/Developers/Python_scripting
-            views = slicer.app.layoutManager().sliceViewNames()
-            for view in views:
-                view_logic = slicer.app.layoutManager().sliceWidget(view).sliceLogic()
-                view_cn = view_logic.GetSliceCompositeNode()
-                view_cn.SetBackgroundVolumeID(outputVolumeNode.GetID())
-                view_logic.FitSliceToAll()
-            # TODO: hide?
+        outputVolumeNodeID = cvpn.GetOutputVolumeNodeID()
+        outputVolumeNode = slicer.mrmlScene.GetNodeByID(outputVolumeNodeID)
+
+        outputVolumeNode.SetName(f"{targetFrame.GetName()}_{frame_idx}_{self.name}_cropped")
+        #self.croppedCtSequence.SetDataNodeAtValue(outputVolumeNode, str(frame_idx))
+        self.croppedCtSequence[frame_idx] = outputVolumeNode
+        # TODO: remove new node from scene (we want it visible just inside the sequence...)?
 
         return outputVolumeNode
 
@@ -150,38 +164,39 @@ class TreeNode:
             return None
         return AutoscoperMLogic.getItemInSequence(self.transformSequence, idx)[0]
 
+    def getCroppedFrame(self, idx: int) -> slicer.vtkMRMLScalarVolumeNode:
+        """if idx >= self.croppedCtSequence.GetNumberOfDataNodes():
+            logging.warning(f"Provided index {idx} is greater than number of data nodes in the sequence.")
+            return None
+        return self.croppedCtSequence.GetNthDataNode(idx)"""
+        if idx not in self.croppedCtSequence:
+            logging.warning(f"Provided index {idx} not found in the sequence od cropped volumes.")
+            return None
+        return self.croppedCtSequence[idx]
+
     def _applyTransform(self, idx: int, transform: slicer.vtkMRMLTransformNode) -> None:
-        """Applies and hardends a transform node to the transform in the sequence at the provided index."""
+        """Applies and hardends a transform node to the transform sequence at the provided index."""
         if idx >= self.transformSequence.GetNumberOfDataNodes():
             logging.warning(f"Provided index {idx} is greater than number of data nodes in the sequence.")
             return
         current_transform = AutoscoperMLogic.getItemInSequence(self.transformSequence, idx)[0]
-        current_transform.SetAndObserveTransformNodeID(transform.GetID())
+        current_transform.SetAndObserveTransformNodeID(transform.GetID()) # TODO: fails for parent! parent transform cannot be self or a child transform
         current_transform.HardenTransform()
 
-    def setTransformFromNode(self, transform: slicer.vtkMRMLLinearTransformNode, idx: int) -> None:
-        """Sets the transform for the provided index."""
-        if idx >= self.transformSequence.GetNumberOfDataNodes():
-            logging.warning(f"Provided index {idx} is greater than number of data nodes in the sequence.")
-            return
-        mat = vtk.vtkMatrix4x4()
-        transform.GetMatrixTransformToParent(mat)
-        current_transform = AutoscoperMLogic.getItemInSequence(self.transformSequence, idx)[0]
-        current_transform.SetMatrixTransformToParent(mat)
-
-    def setTransformFromMatrix(self, transform: vtk.vtkMatrix4x4, idx: int) -> None: # TODO: revisit for import
+    def setTransformFromMatrix(self, transform: vtk.vtkMatrix4x4, idx: int) -> None:  # TODO: revisit for import
+        """TODO description"""
         if idx >= self.transformSequence.GetNumberOfDataNodes():
             logging.warning(f"Provided index {idx} is greater than number of data nodes in the sequence.")
             return
         current_transform = AutoscoperMLogic.getItemInSequence(self.transformSequence, idx)[0]
         current_transform.SetMatrixTransformToParent(transform)
 
-    def applyTransformToTree(self, idx: int, transform: slicer.vtkMRMLLinearTransformNode) -> None:
+    def applyTransformToChildren(self, idx: int, transform: slicer.vtkMRMLLinearTransformNode) -> None:
         """Applies the transform at the provided index to this node and all its children."""
-        # apply the transform first to this node
-        self._applyTransform(idx, transform)
-        # recurse down all child nodes and apply it to them as well
-        [childNode.applyTransformToTree(idx, transform) for childNode in self.childNodes]
+        for childNode in self.childNodes:
+            childNode._applyTransform(idx, transform)
+            # recurse down all child nodes and apply it to them as well
+            childNode.applyTransformToChildren(idx, transform)
 
     def copyTransformToNextFrame(self, currentIdx: int) -> None:
         """Copies the transform at the provided index to the next frame."""
@@ -198,7 +213,7 @@ class TreeNode:
         else:
             logging.error(f"DEBUGGING copyTransformToNextFrame: nextTransform is None at nextIdx={nextIdx}")
 
-    def exportTransformsAsTRAFile(self, exportDir: str): # TODO: revisit for export
+    def exportTransformsAsTRAFile(self, exportDir: str):  # TODO: revisit for export
         """Exports the sequence as a TRA file for reading into Autoscoper."""
         # Convert the sequence to a list of vtkMatrices
         transforms = []
@@ -213,7 +228,8 @@ class TreeNode:
         filename = os.path.join(exportDir, f"{self.name}-abs-RAS.tra")
         IO.writeTRA(filename, transforms)
 
-    def importTransfromsFromTRAFile(self, filename: str): # TODO: revisit for import
+    def importTransfromsFromTRAFile(self, filename: str):  # TODO: revisit for import
+        """TODO description"""
         import numpy as np
 
         tra = np.loadtxt(filename, delimiter=",")

--- a/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
+++ b/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
@@ -113,15 +113,11 @@ class TreeNode:
         Return a cropped volume from the given CT frame based on the initial guess
         transform for the given frame and this model's ROI.
         """
-        # TODO: user to manual adjust the initial transform
-
         initial_tfm = self.getTransform(frameIdx)  # for the root node, this will just be the identity
         # generate cropped volume from the given frame
         self.model.SetAndObserveTransformNodeID(initial_tfm.GetID())
         self.roi.SetAndObserveTransformNodeID(initial_tfm.GetID())
         self.cropFrameFromRoi(frameIdx, ctFrame)
-
-        return initial_tfm
 
     def cropFrameFromRoi(self, frame_idx, targetFrame) -> None:
         """

--- a/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
+++ b/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
@@ -229,13 +229,6 @@ class TreeNode:
         current_transform.SetAndObserveTransformNodeID(transform.GetID())
         current_transform.HardenTransform()
 
-    def setTransformFromMatrix(self, transform: vtk.vtkMatrix4x4, idx: int) -> None:  # TODO: revisit for import
-        """TODO description"""
-        current_transform = self.getTransform(idx)
-        if current_transform is None:
-            return
-        current_transform.SetMatrixTransformToParent(transform)
-
     def applyTransformToChildren(self, idx: int, transform: slicer.vtkMRMLLinearTransformNode) -> None:
         """Applies the transform at the provided index to all children of this node."""
         for childNode in self.childNodes:
@@ -262,7 +255,15 @@ class TreeNode:
         for childNode in self.childNodes:
             childNode.setModelsVisibility(visibility)
 
-    def exportTransformsAsTRAFile(self, exportDir: str):  # TODO: revisit for export
+    def setTransformFromMatrix(self, transform: vtk.vtkMatrix4x4, idx: int) -> None:
+        """Sets the registration transform for the given index from the input matrix"""
+        current_transform = self.getTransform(idx)
+        if current_transform is None:
+            raise ValueError(f"Could not set transform at index {idx} of '{self.transformSequence.GetName()}'.")
+        current_transform.SetMatrixTransformToParent(transform)
+        self.model.SetAndObserveTransformNodeID(current_transform.GetID())
+
+    def exportTransformsAsTRAFile(self, exportDir: str):
         """Exports the sequence as a TRA file for reading into Autoscoper."""
         # Convert the sequence to a list of vtkMatrices
         transforms = []
@@ -277,8 +278,8 @@ class TreeNode:
         filename = os.path.join(exportDir, f"{self.name}-abs-RAS.tra")
         IO.writeTRA(filename, transforms)
 
-    def importTransfromsFromTRAFile(self, filename: str):  # TODO: revisit for import
-        """TODO description"""
+    def importTransfromsFromTRAFile(self, filename: str):
+        """Loads a TRA file as the registration transform sequence"""
         import numpy as np
 
         tra = np.loadtxt(filename, delimiter=",")

--- a/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
+++ b/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
@@ -146,16 +146,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1" colspan="5">
-       <widget class="QPushButton" name="initHierarchyButton">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="text">
-         <string>Initialize Hierarchy Transforms</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>

--- a/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
+++ b/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
@@ -206,6 +206,9 @@
         <property name="text">
          <string/>
         </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>statusMsg</string>
+        </property>
         <property name="styleSheet">
          <string notr="true">color: blue;</string>
         </property>

--- a/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
+++ b/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
@@ -17,14 +17,40 @@
       <string>Registration</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="4" column="0">
-       <widget class="QLabel" name="label_2">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
         <property name="text">
-         <string>Frames</string>
+         <string>Hierarchy:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1" colspan="5">
+      <item row="0" column="1" colspan="5">
+       <widget class="qMRMLSubjectHierarchyComboBox" name="SubjectHierarchyComboBox">
+        <property name="includeItemAttributeNamesFilter">
+         <stringlist notr="true"/>
+        </property>
+        <property name="includeNodeAttributeNamesFilter">
+         <stringlist notr="true"/>
+        </property>
+        <property name="excludeItemAttributeNamesFilter">
+         <stringlist notr="true"/>
+        </property>
+        <property name="excludeNodeAttributeNamesFilter">
+         <stringlist notr="true"/>
+        </property>
+        <!-- <property name="SlicerParameterName" stdset="0"> -->
+        <!--  <string>hierarchyRootID</string> -->
+        <!-- </property> -->
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Input CT Sequence:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="5">
        <widget class="qMRMLNodeComboBox" name="inputSelectorCT">
         <property name="enabled">
          <bool>false</bool>
@@ -47,11 +73,18 @@
          <bool>false</bool>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>inputVolumeSequence</string>
+         <string>volumeSequence</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Frames:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
        <widget class="QSpinBox" name="startFrame">
         <property name="minimum">
          <number>0</number>
@@ -62,62 +95,12 @@
         <property name="value">
          <number>0</number>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="1" colspan="5">
-       <widget class="qMRMLSubjectHierarchyComboBox" name="SubjectHierarchyComboBox">
-        <property name="includeItemAttributeNamesFilter">
-         <stringlist notr="true"/>
-        </property>
-        <property name="includeNodeAttributeNamesFilter">
-         <stringlist notr="true"/>
-        </property>
-        <property name="excludeItemAttributeNamesFilter">
-         <stringlist notr="true"/>
-        </property>
-        <property name="excludeNodeAttributeNamesFilter">
-         <stringlist notr="true"/>
-        </property>
-        <!-- <property name="SlicerParameterName" stdset="0"> -->
-        <!--  <string>inputHierarchyRootID</string> -->
-        <!-- </property> -->
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Input CT Sequence:</string>
+        <property name="SlicerParameterName" stdset="0">
+         <string>startFrame</string>
         </property>
        </widget>
       </item>
-      <item row="5" column="1" colspan="5">
-       <widget class="QPushButton" name="applyButton">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Run the algorithm.</string>
-        </property>
-        <property name="text">
-         <string>Apply</string>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QCheckBox" name="onlyTrackRootNodeCheckBox">
-        <property name="text">
-         <string>Track Root Node Only</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Hierarchy:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="4">
+      <item row="2" column="2" colspan="3">
        <widget class="ctkRangeSlider" name="frameSlider">
         <property name="maximum">
          <number>0</number>
@@ -136,13 +119,95 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="5">
+      <item row="2" column="5">
        <widget class="QSpinBox" name="endFrame">
         <property name="maximum">
          <number>0</number>
         </property>
         <property name="value">
          <number>0</number>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>endFrame</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0" colspan="2">
+       <widget class="QCheckBox" name="onlyTrackRootNodeCheckBox">
+        <property name="text">
+         <string>Track Root Node Only</string>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>trackOnlyRoot</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QCheckBox" name="skipManualTfmAdjustmentCheckBox">
+        <property name="text">
+         <string>Skip Initial Guess Adjustment</string>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>skipManualTfmAdjustments</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="6">
+       <layout class="QGridLayout" name="trackingButtonsLayout">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="abortButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Abort the current registration process.</string>
+          </property>
+          <property name="text">
+           <string>Abort</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QPushButton" name="initializeButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Begin the registration process for the selected input fields.</string>
+          </property>
+          <property name="text">
+           <string>Initialize Registration</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QPushButton" name="registerButton">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>Run the algorithm.</string>
+          </property>
+          <property name="text">
+           <string>Set Initial Guess</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="5" column="0" colspan="6">
+       <widget class="QLabel" name="registrationStatusLabel">
+		<property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="styleSheet">
+         <string notr="true">color: blue;</string>
         </property>
        </widget>
       </item>

--- a/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
+++ b/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
@@ -18,13 +18,85 @@
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0">
+       <widget class="QLabel" name="inputCTSequenceLabel">
+        <property name="text">
+         <string>Input CT Sequence:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="5">
+       <widget class="qMRMLNodeComboBox" name="inputCTSequenceSelector">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the input to the algorithm.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLScalarVolumeNode</string>
+          <string>vtkMRMLSequenceNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>volumeSequence</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="inputSourceCTLabel">
+        <property name="text">
+         <string>Source Volume:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1" colspan="5">
+       <widget class="qMRMLNodeComboBox" name="inputSourceCTSelector">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Pick the volume from which the models were generated, to be registered against the input sequence.</string>
+        </property>
+        <property name="nodeTypes">
+         <stringlist notr="true">
+          <string>vtkMRMLScalarVolumeNode</string>
+         </stringlist>
+        </property>
+        <property name="showChildNodeTypes">
+         <bool>false</bool>
+        </property>
+        <property name="addEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="removeEnabled">
+         <bool>false</bool>
+        </property>
+        <property name="interactionNodeSingletonTag">
+         <string notr="true"/>
+        </property>
+        <property name="SlicerParameterName" stdset="0">
+         <string>sourceVolume</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>Hierarchy:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1" colspan="5">
+      <item row="2" column="1" colspan="5">
        <widget class="qMRMLSubjectHierarchyComboBox" name="SubjectHierarchyComboBox">
         <property name="includeItemAttributeNamesFilter">
          <stringlist notr="true"/>
@@ -43,48 +115,14 @@
         <!-- </property> -->
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Input CT Sequence:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="5">
-       <widget class="qMRMLNodeComboBox" name="inputSelectorCT">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Pick the input to the algorithm.</string>
-        </property>
-        <property name="nodeTypes">
-         <stringlist notr="true">
-          <string>vtkMRMLScalarVolumeNode</string>
-         </stringlist>
-        </property>
-        <property name="showChildNodeTypes">
-         <bool>false</bool>
-        </property>
-        <property name="addEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="removeEnabled">
-         <bool>false</bool>
-        </property>
-        <property name="SlicerParameterName" stdset="0">
-         <string>volumeSequence</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_2">
         <property name="text">
          <string>Frames:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QSpinBox" name="startFrame">
         <property name="minimum">
          <number>0</number>
@@ -100,7 +138,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2" colspan="3">
+      <item row="3" column="2" colspan="3">
        <widget class="ctkRangeSlider" name="frameSlider">
         <property name="maximum">
          <number>0</number>
@@ -119,7 +157,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="5">
+      <item row="3" column="5">
        <widget class="QSpinBox" name="endFrame">
         <property name="maximum">
          <number>0</number>
@@ -132,7 +170,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="4" column="0" colspan="2">
        <widget class="QCheckBox" name="onlyTrackRootNodeCheckBox">
         <property name="text">
          <string>Track Root Node Only</string>
@@ -142,7 +180,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
+      <item row="4" column="2">
        <widget class="QCheckBox" name="skipManualTfmAdjustmentCheckBox">
         <property name="text">
          <string>Skip Initial Guess Adjustment</string>
@@ -152,7 +190,7 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="6">
+      <item row="5" column="0" colspan="6">
        <layout class="QGridLayout" name="trackingButtonsLayout">
         <item row="0" column="0">
          <widget class="QPushButton" name="abortButton">
@@ -189,15 +227,15 @@
            <string>Run the algorithm.</string>
           </property>
           <property name="text">
-           <string>Set Initial Guess</string>
+           <string>Set Initial Guess And Register</string>
           </property>
          </widget>
         </item>
        </layout>
       </item>
-      <item row="5" column="0" colspan="6">
+      <item row="6" column="0" colspan="6">
        <widget class="QLabel" name="registrationStatusLabel">
-		<property name="font">
+        <property name="font">
          <font>
           <weight>75</weight>
           <bold>true</bold>
@@ -309,7 +347,7 @@
   <connection>
    <sender>Tracking3D</sender>
    <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
-   <receiver>inputSelectorCT</receiver>
+   <receiver>inputCTSequenceSelector</receiver>
    <slot>setMRMLScene(vtkMRMLScene*)</slot>
    <hints>
     <hint type="sourcelabel">
@@ -399,6 +437,22 @@
     <hint type="destinationlabel">
      <x>469</x>
      <y>148</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>Tracking3D</sender>
+   <signal>mrmlSceneChanged(vtkMRMLScene*)</signal>
+   <receiver>inputSourceCTSelector</receiver>
+   <slot>setMRMLScene(vtkMRMLScene*)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>392</x>
+     <y>280</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>453</x>
+     <y>116</y>
     </hint>
    </hints>
   </connection>

--- a/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
+++ b/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
@@ -166,7 +166,7 @@
          <number>0</number>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>startFrame</string>
+         <string>startFrameIdx</string>
         </property>
        </widget>
       </item>
@@ -198,7 +198,7 @@
          <number>0</number>
         </property>
         <property name="SlicerParameterName" stdset="0">
-         <string>endFrame</string>
+         <string>endFrameIdx</string>
         </property>
        </widget>
       </item>

--- a/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
+++ b/Hierarchical3DRegistration/Resources/UI/Hierarchical3DRegistration.ui
@@ -12,6 +12,38 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="value">
+      <number>0</number>
+     </property>
+     <property name="invertedAppearance">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="registrationStatusLabel">
+     <property name="font">
+      <font>
+       <weight>75</weight>
+       <bold>true</bold>
+      </font>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+     <property name="SlicerParameterName" stdset="0">
+      <string>statusMsg</string>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: palette(link);</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="ctkCollapsibleButton" name="inputsCollapsibleButton">
      <property name="text">
       <string>Registration</string>
@@ -232,25 +264,6 @@
          </widget>
         </item>
        </layout>
-      </item>
-      <item row="6" column="0" colspan="6">
-       <widget class="QLabel" name="registrationStatusLabel">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string/>
-        </property>
-        <property name="SlicerParameterName" stdset="0">
-         <string>statusMsg</string>
-        </property>
-        <property name="styleSheet">
-         <string notr="true">color: blue;</string>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Reimplements https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/99 following the approach discussed in:
- https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/149
- https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/150
- https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/151
and using some of the logic proposed in https://github.com/BrownBiomechanics/SlicerAutoscoperM/pull/152.

Tested using https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/110.

TODO:
- [x] https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/165
- [x] https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/166
  - [x] Fix ROI cropping when transform is also applied
- [x] fix improper transform propagation  
- [x] improve status message visiblity
- [x] enable volume render visibility of current frame being registered
- [x] clean up code and add comments to better document it
- [x] hide intermediate result data nodes from the scene, store cropped volumes in sequence
- [x] https://github.com/BrownBiomechanics/Autoscoper/pull/311
- [x] revisit export of registration results (and import ) 

**Edit: This will be outsourced to another team member**
- [ ] test on a bigger variety of datasets

**Edit: Not to be tackled immediately**
- [ ] quantify error in resulting transforms with respect to ground truth data

