### PR TITLE
ENH: Integrate Autoscoper compiled with collision detection

### DIFF
--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -48,6 +48,20 @@
          <item>
           <widget class="QComboBox" name="autoscoperRenderingBackendComboBox"/>
          </item>
+         <item>
+          <widget class="QComboBox" name="autoscoperCollisionDetectionComboBox">
+           <item>
+            <property name="text">
+             <string>With Collision Detection</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Without Collision Detection</string>
+            </property>
+           </item>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/AutoscoperM/Resources/UI/AutoscoperM.ui
+++ b/AutoscoperM/Resources/UI/AutoscoperM.ui
@@ -48,20 +48,6 @@
          <item>
           <widget class="QComboBox" name="autoscoperRenderingBackendComboBox"/>
          </item>
-         <item>
-          <widget class="QComboBox" name="autoscoperCollisionDetectionComboBox">
-           <item>
-            <property name="text">
-             <string>With Collision Detection</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Without Collision Detection</string>
-            </property>
-           </item>
-          </widget>
-         </item>
         </layout>
        </item>
        <item>

--- a/SuperBuild.cmake
+++ b/SuperBuild.cmake
@@ -19,6 +19,7 @@ set(proj ${SUPERBUILD_TOPLEVEL_PROJECT})
 # Project dependencies
 set(${proj}_DEPENDS
   Autoscoper-OpenCL
+  Autoscoper-OpenCL-CollisionDetection
   )
 
 if(DEFINED ENV{SlicerAutoscoperM_CUDA_PATH})
@@ -50,6 +51,7 @@ if(CMAKE_CUDA_COMPILER)
   endif()
   list(APPEND ${proj}_DEPENDS
     Autoscoper-CUDA
+    Autoscoper-CUDA-CollisionDetection
     )
 endif()
 

--- a/SuperBuild/External_Autoscoper-CUDA-CollisionDetection.cmake
+++ b/SuperBuild/External_Autoscoper-CUDA-CollisionDetection.cmake
@@ -1,4 +1,4 @@
-set(proj Autoscoper-CUDA)
+set(proj Autoscoper-CUDA-CollisionDetection)
 set(${proj}_RENDERING_BACKEND CUDA)
-set(${proj}_COLLISION_DETECTION 0)
+set(${proj}_COLLISION_DETECTION 1)
 include(${CMAKE_CURRENT_LIST_DIR}/External_Autoscoper.cmake)

--- a/SuperBuild/External_Autoscoper-OpenCL-CollisionDetection.cmake
+++ b/SuperBuild/External_Autoscoper-OpenCL-CollisionDetection.cmake
@@ -1,4 +1,4 @@
-set(proj Autoscoper-OpenCL)
+set(proj Autoscoper-OpenCL-CollisionDetection)
 set(${proj}_RENDERING_BACKEND OpenCL)
-set(${proj}_COLLISION_DETECTION 0)
+set(${proj}_COLLISION_DETECTION 1)
 include(${CMAKE_CURRENT_LIST_DIR}/External_Autoscoper.cmake)

--- a/SuperBuild/External_Autoscoper.cmake
+++ b/SuperBuild/External_Autoscoper.cmake
@@ -35,7 +35,7 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
 
   ExternalProject_SetIfNotDefined(
     Slicer_${proj}_GIT_TAG
-    "8bb1c4e07430dcc53c9771582b97f3bbb9ed2347"
+    "051bc0fbcf53fed7cb7f85e74063584be0f6ee7d"
     QUIET
   )
 
@@ -65,6 +65,10 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
     message(FATAL_ERROR "${proj}RENDERING_BACKEND must be set to CUDA or OpenCL")
   endif()
 
+  if(NOT DEFINED ${proj}_COLLISION_DETECTION OR NOT "${${proj}_COLLISION_DETECTION}" MATCHES "^(0|1)$")
+    message(FATAL_ERROR "${proj}_COLLISION_DETECTION must be set to 0 or 1")
+  endif()
+
   if(${proj}_RENDERING_BACKEND STREQUAL "OpenCL")
     set(${proj}_OPENCL_USE_ICD_LOADER TRUE)
     if(APPLE)
@@ -86,8 +90,17 @@ if(NOT DEFINED ${proj}_DIR AND NOT ${SUPERBUILD_TOPLEVEL_PROJECT}_USE_SYSTEM_${p
       )
   endif()
 
+  if(${proj}_COLLISION_DETECTION)
+    list(APPEND EXTERNAL_PROJECT_OPTIONAL_CMAKE_CACHE_ARGS
+      -DVTK_DIR:STRING=${VTK_DIR}
+      )
+  endif()
+
   if(NOT DEFINED ${proj}_ARTIFACT_SUFFIX)
     set(${proj}_ARTIFACT_SUFFIX "-${${proj}_RENDERING_BACKEND}")
+    if(${proj}_COLLISION_DETECTION)
+      set(${proj}_ARTIFACT_SUFFIX "${${proj}_ARTIFACT_SUFFIX}-CollisionDetection")
+    endif()
   endif()
   ExternalProject_Message(${proj} "${proj}_ARTIFACT_SUFFIX:${${proj}_ARTIFACT_SUFFIX}")
 


### PR DESCRIPTION
Resolves https://github.com/BrownBiomechanics/SlicerAutoscoperM/issues/174

This PR follows up on https://github.com/BrownBiomechanics/Autoscoper/pull/295 to distribute the compiled binaries of Autoscoper when compiled with or without the collision detection feature enabled. 

There should now be a matrix of binaries built and able to be loaded, either with a CUDA/OpenCL (or neither) backend, and with or without collision detection enabled. 
![image](https://github.com/user-attachments/assets/ec23bed8-8c57-4bd2-bf75-d1c96aa9a41d)

TODO: 
- [x] Add UI features and python logic to load the correct binary for the configuration selected
- [x] Modify CMake superbuild to also build each configuration with and without collision detection.
  - Add VTK dependency
  - Blocked until https://github.com/BrownBiomechanics/Autoscoper/pull/295 determines the final set of CMake options to build Autoscoper with collision detection enabled/disabled.
- [ ] revert [this git repository reference](https://github.com/BrownBiomechanics/SlicerAutoscoperM/blob/dbfce0872e5761e76c112881eed80f27f1e2f893/SuperBuild/External_Autoscoper.cmake#L32) in the superbuild once https://github.com/BrownBiomechanics/Autoscoper/pull/295 is merged