### PR TITLE
BUG: Generate roi in model-defined orientation

### DIFF
--- a/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
+++ b/Hierarchical3DRegistration/Hierarchical3DRegistrationLib/TreeNode.py
@@ -85,17 +85,12 @@ class TreeNode:
         # Compute centroids
 
         segStatLogic = SegmentStatistics.SegmentStatisticsLogic()
-        segStatLogic.getParameterNode().SetParameter("Segmentation", segNode.GetID())
-        segStatLogic.getParameterNode().SetParameter("LabelmapSegmentStatisticsPlugin.centroid_ras.enabled", str(True))
-        segStatLogic.getParameterNode().SetParameter(
-            "LabelmapSegmentStatisticsPlugin.principal_axis_x.enabled", str(True)
-        )
-        segStatLogic.getParameterNode().SetParameter(
-            "LabelmapSegmentStatisticsPlugin.principal_axis_y.enabled", str(True)
-        )
-        segStatLogic.getParameterNode().SetParameter(
-            "LabelmapSegmentStatisticsPlugin.principal_axis_z.enabled", str(True)
-        )
+        segStatParams = segStatLogic.getParameterNode()
+        segStatParams.SetParameter("Segmentation", segNode.GetID())
+        segStatParams.SetParameter("LabelmapSegmentStatisticsPlugin.centroid_ras.enabled", str(True))
+        segStatParams.SetParameter("LabelmapSegmentStatisticsPlugin.principal_axis_x.enabled", str(True))
+        segStatParams.SetParameter("LabelmapSegmentStatisticsPlugin.principal_axis_y.enabled", str(True))
+        segStatParams.SetParameter("LabelmapSegmentStatisticsPlugin.principal_axis_z.enabled", str(True))
         segStatLogic.computeStatistics()
         stats = segStatLogic.getStatistics()
 


### PR DESCRIPTION
Generated using segmentation statistics module, each model is cloned and a principle rotation axis computed to form model-derived coordinate system basis.


Roi are constructed from bounding box dimensions of the models in the space and back transformed to source space by the inverse linear transform.![Screenshot 2025-04-21 142553](https://github.com/user-attachments/assets/64a8c0f0-c938-4121-8c78-8acdb95afb36)

Preliminary  registration results fix previously reported errors:

![Screenshot 2025-04-21 142629](https://github.com/user-attachments/assets/8905ec1c-0d9f-456a-8ff2-41cfb80c4e86)
