### PR TITLE
BUG: Fix SampleData download to align with revised file loading behavior

### DIFF
--- a/AutoscoperM/AutoscoperM.py
+++ b/AutoscoperM/AutoscoperM.py
@@ -113,6 +113,8 @@ def registerAutoscoperSampleData(dataType, version, checksum):
         # This node name will be used when the data set is loaded
         # nodeNames=f"AutoscoperM - {dataType} BVR" # comment this line so the data is not loaded into the scene
         customDownloader=downloadAndExtract,
+        # File format name(s) (if not specified then the default file reader will be used).
+        loadFileTypes="ZipFile",
     )
 
 


### PR DESCRIPTION
Set `loadFileType` to "ZipFile" to verify that the data are downloaded without attempting to load.

Adapted from Slicer/Slicer@b4c0882a8ed ("BUG: Fix SampleData tests to align with revised file loading behavior", 2025-01-22)